### PR TITLE
Recent updates to ABACUS-agent-tools

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -24,6 +24,9 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install pymatgen
+      run: |
+          pip install pymatgen==2025.5.28
     - name: Install dependencies
       run: |
           git clone https://github.com/pxlxingliang/abacus-test.git

--- a/src/abacusagent/modules/abacus.py
+++ b/src/abacusagent/modules/abacus.py
@@ -104,7 +104,7 @@ def generate_bulk_structure(element: str,
         }
     except Exception as e:
         return {
-            "structure_file": Path(''),
+            "structure_file": None,
             "cell": None,
             "coordinate": None,
             "message": f"Generating bulk structure failed: {e}"
@@ -229,7 +229,7 @@ def generate_molecule_structure(
         }
     except Exception as e:
         return {
-            "structure_file": Path(''),
+            "structure_file": None,
             "cell": None,
             "coordinate": None,
             "message": f"Generating molecule structure failed: {e}"
@@ -339,7 +339,7 @@ def abacus_prepare(
                 "input_content": input_content,
                 "input_files": input_files}
     except Exception as e:
-        return {"job_path": Path(''),
+        return {"job_path": None,
                 "input_content": None,
                 "input_files": None,
                 "message": f"Prepare ABACUS input files from given structure failed: {e}"}
@@ -470,7 +470,7 @@ def abacus_modify_input(
         return {'abacusjob_dir': abacusjob_dir,
                 'input_content': input_param}
     except Exception as e:
-        return {'abacusjob_dir': Path(''),
+        return {'abacusjob_dir': None,
                 'input_content': None,
                 'message': f"Modify ABACUS INPUT file failed: {e}"}
 
@@ -605,7 +605,7 @@ def abacus_modify_stru(
                 'stru_content': stru_content 
                 }
     except Exception as e:
-        return {'abacusjob_dir': Path(''),
+        return {'abacusjob_dir': None,
                 'stru_content': None,
                 'message': f"Modify ABACUS STRU file failed: {e}"
                 }
@@ -725,18 +725,15 @@ def abacus_collect_data(
     """
     try:
         abacusjob = Path(abacusjob)
-        try:
-            abacusresult = RESULT(fmt="abacus", path=abacusjob)
-        except:
-            raise IOError("Read abacus result failed")
-
+        abacusresult = RESULT(fmt="abacus", path=abacusjob)
+        
         collected_metrics = {}
         for metric in metrics:
             try:
                 collected_metrics[metric] = abacusresult[metric]
             except Exception as e:
-                raise RuntimeError(f"Error during collecting {metric}")
-
+                collected_metrics[metric] = None
+                
         metric_file_path = os.path.join(abacusjob, "metrics.json")
         with open(metric_file_path, "w", encoding="UTF-8") as f:
             json.dump(collected_metrics, f, indent=4)

--- a/src/abacusagent/modules/abacus.py
+++ b/src/abacusagent/modules/abacus.py
@@ -752,7 +752,7 @@ def abacus_collect_data(
         return {'collected_metrics': None,
                 'message': f'Collectiong results from ABACUS output files failed: {e}'}
 
-@mcp.tool()
+#@mcp.tool()
 def run_abacus_onejob(
     abacusjob: Path,
 ) -> Dict[str, Any]:

--- a/src/abacusagent/modules/abacus.py
+++ b/src/abacusagent/modules/abacus.py
@@ -320,7 +320,8 @@ def abacus_prepare(
                 dftu=dftu,
                 dftu_param=dftu_param,
                 init_mag=init_mag,
-                afm=afm
+                afm=afm,
+                copy_pp_orb=True
             ).run()  
         except Exception as e:
             os.chdir(pwd)

--- a/src/abacusagent/modules/abacus.py
+++ b/src/abacusagent/modules/abacus.py
@@ -65,45 +65,53 @@ def generate_bulk_structure(element: str,
     >>> gaas_zincblende = generate_bulk_structure('GaAs', 'zincblende', a=5.65, cubic=True)
     
     """
-    if a is None:
-        raise ValueError("Lattice constant 'a' must be provided for all crystal structures.")
-    
-    from ase.build import bulk
-    special_params = {}
-    
-    if crystal_structure == 'hcp':
-        if c is not None:
-            special_params['c'] = c
-        special_params['orthorhombic'] = orthorhombic
-    
-    if crystal_structure in ['fcc', 'bcc', 'diamond', 'zincblende']:
-        special_params['cubic'] = cubic
     try:
-        structure = bulk(
-            name=element,
-            crystalstructure=crystal_structure,
-            a=a,
-            **special_params
-        )
+        if a is None:
+            raise ValueError("Lattice constant 'a' must be provided for all crystal structures.")
+
+        from ase.build import bulk
+        special_params = {}
+
+        if crystal_structure == 'hcp':
+            if c is not None:
+                special_params['c'] = c
+            special_params['orthorhombic'] = orthorhombic
+
+        if crystal_structure in ['fcc', 'bcc', 'diamond', 'zincblende']:
+            special_params['cubic'] = cubic
+        try:
+            structure = bulk(
+                name=element,
+                crystalstructure=crystal_structure,
+                a=a,
+                **special_params
+            )
+        except Exception as e:
+            raise ValueError(f"Generate structure failed: {str(e)}") from e
+
+        work_path = generate_work_path(create=True)
+
+        if file_format == "cif":
+            structure_file = f"{work_path}/{element}_{crystal_structure}.cif"
+            structure.write(structure_file, format="cif")
+        elif file_format == "poscar":
+            structure_file = f"{work_path}/{element}_{crystal_structure}.vasp"
+            structure.write(structure_file, format="vasp")
+        else:
+            raise ValueError("Unsupported file format. Use 'cif' or 'poscar'.")
+
+        return {
+            "structure_file": Path(structure_file).absolute(),
+            "cell": structure.get_cell().tolist(),
+            "coordinate": structure.get_positions().tolist()
+        }
     except Exception as e:
-        raise ValueError(f"Generate structure failed: {str(e)}") from e
-    
-    work_path = generate_work_path(create=True)
-    
-    if file_format == "cif":
-        structure_file = f"{work_path}/{element}_{crystal_structure}.cif"
-        structure.write(structure_file, format="cif")
-    elif file_format == "poscar":
-        structure_file = f"{work_path}/{element}_{crystal_structure}.vasp"
-        structure.write(structure_file, format="vasp")
-    else:
-        raise ValueError("Unsupported file format. Use 'cif' or 'poscar'.")
-    
-    return {
-        "structure_file": Path(structure_file).absolute(),
-        "cell": structure.get_cell().tolist(),
-        "coordinate": structure.get_positions().tolist()
-    }
+        return {
+            "structure_file": Path(''),
+            "cell": None,
+            "coordinate": None,
+            "message": f"Generating bulk structure failed: {e}"
+        }
 
 @mcp.tool()
 def generate_bulk_structure_from_wyckoff_position(
@@ -133,20 +141,24 @@ def generate_bulk_structure_from_wyckoff_position(
 
     Raises:
     """
-    lattice = Lattice.from_parameters(a=a, b=b, c=c, alpha=alpha, beta=beta, gamma=gamma)
-    
-    crys_stru = Structure.from_spacegroup(
-        sg=spacegroup,
-        lattice=lattice,
-        species=[wyckoff_position[0] for wyckoff_position in wyckoff_positions],
-        coords=[wyckoff_position[1] for wyckoff_position in wyckoff_positions],
-        tol=0.001,
-    )
+    try:
+        lattice = Lattice.from_parameters(a=a, b=b, c=c, alpha=alpha, beta=beta, gamma=gamma)
 
-    crys_file_name = Path(f"{crystal_name}.{format}").absolute()
-    write(crys_file_name, crys_stru.to_ase_atoms(), format)
+        crys_stru = Structure.from_spacegroup(
+            sg=spacegroup,
+            lattice=lattice,
+            species=[wyckoff_position[0] for wyckoff_position in wyckoff_positions],
+            coords=[wyckoff_position[1] for wyckoff_position in wyckoff_positions],
+            tol=0.001,
+        )
 
-    return {"structure_file": crys_file_name}
+        crys_file_name = Path(f"{crystal_name}.{format}").absolute()
+        write(crys_file_name, crys_stru.to_ase_atoms(), format)
+
+        return {"structure_file": crys_file_name}
+    except Exception as e:
+        return {"structure_file": Path(''),
+                "message": f"Generating bulk structure from Wyckoff position failed: {e}"}
 
 @mcp.tool()
 def generate_molecule_structure(
@@ -196,27 +208,35 @@ def generate_molecule_structure(
         - cell: The cell parameters of the generated structure as a list of lists.
         - coordinate: The atomic coordinates of the generated structure as a list of lists.
     """
-    if output_file_format == "poscar":
-        output_file_format = "vasp"  # ASE uses 'vasp' format for POSCAR files
-    if molecule_name in g2.names:
-        atoms = molecule(molecule_name)
-        atoms.set_cell(cell)
-        atoms.center(vacuum=vacuum)
-    elif molecule_name in chemical_symbols and molecule_name != "X":
-        atoms = Atoms(symbol=molecule_name, positions=[[0, 0, 0]], cell=cell)
-    
-    if output_file_format == "abacus":
-        stru_file_path = Path(f"{molecule_name}.stru").absolute()
-    else:
-        stru_file_path = Path(f"{molecule_name}.{output_file_format}").absolute()
-    
-    atoms.write(stru_file_path, format=output_file_format)
+    try:
+        if output_file_format == "poscar":
+            output_file_format = "vasp"  # ASE uses 'vasp' format for POSCAR files
+        if molecule_name in g2.names:
+            atoms = molecule(molecule_name)
+            atoms.set_cell(cell)
+            atoms.center(vacuum=vacuum)
+        elif molecule_name in chemical_symbols and molecule_name != "X":
+            atoms = Atoms(symbol=molecule_name, positions=[[0, 0, 0]], cell=cell)
 
-    return {
-        "structure_file": Path(stru_file_path).absolute(),
-        "cell": atoms.get_cell().tolist(),
-        "coordinate": atoms.get_positions().tolist()
-    }
+        if output_file_format == "abacus":
+            stru_file_path = Path(f"{molecule_name}.stru").absolute()
+        else:
+            stru_file_path = Path(f"{molecule_name}.{output_file_format}").absolute()
+
+        atoms.write(stru_file_path, format=output_file_format)
+
+        return {
+            "structure_file": Path(stru_file_path).absolute(),
+            "cell": atoms.get_cell().tolist(),
+            "coordinate": atoms.get_positions().tolist()
+        }
+    except Exception as e:
+        return {
+            "structure_file": Path(''),
+            "cell": None,
+            "coordinate": None,
+            "message": f"Generating molecule structure failed: {e}"
+        }
 
 @mcp.tool()
 def abacus_prepare(
@@ -263,63 +283,69 @@ def abacus_prepare(
         ValueError: If LCAO basis set is selected but no orbital library path is provided.
         RuntimeError: If there is an error preparing input files.
     """
-    stru_file = Path(stru_file).absolute()
-    if not os.path.isfile(stru_file):
-        raise FileNotFoundError(f"Structure file {stru_file} does not exist.")
-    
-    # Check if the pseudopotential path exists
-    pp_path = pp_path if pp_path is not None else os.getenv("ABACUS_PP_PATH")
-    if pp_path is None or not os.path.exists(pp_path):
-        raise FileNotFoundError(f"Pseudopotential path {pp_path} does not exist.")
-    
-    orb_path = orb_path if orb_path is not None else os.getenv("ABACUS_ORB_PATH")
-    if orb_path is None and os.getenv("ABACUS_ORB_PATH") is not None:
-        orb_path = os.getenv("ABACUS_ORB_PATH")
-    
-    if lcao and orb_path is None:
-        raise ValueError("LCAO basis set is selected but no orbital library path is provided.")
-    
-    work_path = generate_work_path()
-    pwd = os.getcwd()
-    os.chdir(work_path)
     try:
-        extra_input_file = None
-        if extra_input is not None:
-            # write extra input to the input file
-            extra_input_file = Path("INPUT.tmp").absolute()
-            WriteInput(extra_input, extra_input_file)
-    
-        _, job_path = PrepInput(
-            files=str(stru_file),
-            filetype=stru_type,
-            jobtype=job_type,
-            pp_path=pp_path,
-            orb_path=orb_path,
-            input_file=extra_input_file,
-            lcao=lcao,
-            nspin=nspin,
-            soc=soc,
-            dftu=dftu,
-            dftu_param=dftu_param,
-            init_mag=init_mag,
-            afm=afm
-        ).run()  
-    except Exception as e:
-        os.chdir(pwd)
-        raise RuntimeError(f"Error preparing input files: {e}")
-    
-    if len(job_path) == 0:
-        os.chdir(pwd)
-        raise RuntimeError("No job path returned from PrepInput.")
-    
-    input_content = ReadInput(os.path.join(job_path[0], "INPUT"))
-    input_files = os.listdir(job_path[0])
-    job_path = Path(job_path[0]).absolute()
-    os.chdir(pwd)
+        stru_file = Path(stru_file).absolute()
+        if not os.path.isfile(stru_file):
+            raise FileNotFoundError(f"Structure file {stru_file} does not exist.")
 
-    return {"job_path": job_path,
-            "input_content": input_content,
-            "input_files": input_files}
+        # Check if the pseudopotential path exists
+        pp_path = pp_path if pp_path is not None else os.getenv("ABACUS_PP_PATH")
+        if pp_path is None or not os.path.exists(pp_path):
+            raise FileNotFoundError(f"Pseudopotential path {pp_path} does not exist.")
+
+        orb_path = orb_path if orb_path is not None else os.getenv("ABACUS_ORB_PATH")
+        if orb_path is None and os.getenv("ABACUS_ORB_PATH") is not None:
+            orb_path = os.getenv("ABACUS_ORB_PATH")
+
+        if lcao and orb_path is None:
+            raise ValueError("LCAO basis set is selected but no orbital library path is provided.")
+
+        work_path = generate_work_path()
+        pwd = os.getcwd()
+        os.chdir(work_path)
+        try:
+            extra_input_file = None
+            if extra_input is not None:
+                # write extra input to the input file
+                extra_input_file = Path("INPUT.tmp").absolute()
+                WriteInput(extra_input, extra_input_file)
+
+            _, job_path = PrepInput(
+                files=str(stru_file),
+                filetype=stru_type,
+                jobtype=job_type,
+                pp_path=pp_path,
+                orb_path=orb_path,
+                input_file=extra_input_file,
+                lcao=lcao,
+                nspin=nspin,
+                soc=soc,
+                dftu=dftu,
+                dftu_param=dftu_param,
+                init_mag=init_mag,
+                afm=afm
+            ).run()  
+        except Exception as e:
+            os.chdir(pwd)
+            raise RuntimeError(f"Error preparing input files: {e}")
+
+        if len(job_path) == 0:
+            os.chdir(pwd)
+            raise RuntimeError("No job path returned from PrepInput.")
+
+        input_content = ReadInput(os.path.join(job_path[0], "INPUT"))
+        input_files = os.listdir(job_path[0])
+        job_path = Path(job_path[0]).absolute()
+        os.chdir(pwd)
+
+        return {"job_path": job_path,
+                "input_content": input_content,
+                "input_files": input_files}
+    except Exception as e:
+        return {"job_path": Path(''),
+                "input_content": None,
+                "input_files": None,
+                "message": f"Prepare ABACUS input files from given structure failed: {e}"}
 
 #@mcp.tool()
 def get_file_content(
@@ -375,79 +401,84 @@ def abacus_modify_input(
         FileNotFoundError: If path of given INPUT file does not exist
         RuntimeError: If write modified INPUT file failed
     """
-    input_file = os.path.join(abacusjob_dir, "INPUT")
-    if dft_plus_u_settings is not None:
-        stru_file = os.path.join(abacusjob_dir, "STRU")
-    if not os.path.isfile(input_file):
-        raise FileNotFoundError(f"INPUT file {input_file} does not exist.")
-    
-    # Update simple keys and their values
-    input_param = ReadInput(input_file)
-    if extra_input is not None:
-        for key, value in extra_input.items():
-            input_param[key] = value
- 
-    # Remove keys
-    if remove_input is not None:
-        for param in remove_input:
-            input_param.pop(param,None)
-       
-    # DFT+U settings
-    main_group_elements = [
-    "H", "He", 
-    "Li", "Be", "B", "C", "N", "O", "F", "Ne",
-    "Na", "Mg", "Al", "Si", "P", "S", "Cl", "Ar",
-    "K", "Ca", "Ga", "Ge", "As", "Se", "Br", "Kr",
-    "Rb", "Sr", "In", "Sn", "Sb", "Te", "I", "Xe",
-    "Cs", "Ba", "Tl", "Pb", "Bi", "Po", "At", "Rn",
-    "Fr", "Ra", "Nh", "Fl", "Mc", "Lv", "Ts", "Og" ]
-    transition_metals = [
-    "Sc", "Ti", "V", "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn",
-    "Y", "Zr", "Nb", "Mo", "Tc", "Ru", "Rh", "Pd", "Ag", "Cd",
-    "Hf", "Ta", "W", "Re", "Os", "Ir", "Pt", "Au", "Hg",
-    "Rf", "Db", "Sg", "Bh", "Hs", "Mt", "Ds", "Rg", "Cn"]
-    lanthanides_and_acnitides = [
-    "La", "Ce", "Pr", "Nd", "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu",
-    "Ac", "Th", "Pa", "U", "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr"]
-
-    orbital_corr_map = {'p': 1, 'd': 2, 'f': 3}
-    if dft_plus_u_settings is not None:
-        input_param['dft_plus_u'] = 1
-
-        stru = AbacusStru.ReadStru(stru_file)
-        elements = stru.get_element(number=False,total=False)
-        
-        orbital_corr_param, hubbard_u_param = '', ''
-        for element in elements:
-            if element not in dft_plus_u_settings:
-                orbital_corr_param += ' -1 '
-                hubbard_u_param += ' 0 '
-            else:
-                if type(dft_plus_u_settings[element]) is not float: # orbital_corr and hubbard_u are provided
-                    orbital_corr = orbital_corr_map[dft_plus_u_settings[element][0]]
-                    orbital_corr_param += f" {orbital_corr} "
-                    hubbard_u_param += f" {dft_plus_u_settings[element][1]} "
-                else: #Only hubbard_u is provided, use default orbital_corr
-                    if element in main_group_elements:
-                        default_orb_corr = 1
-                    elif element in transition_metals:
-                        default_orb_corr = 2
-                    elif element in lanthanides_and_acnitides:
-                        default_orb_corr = 3
-                    
-                    orbital_corr_param += f" {default_orb_corr} "
-                    hubbard_u_param += f" {dft_plus_u_settings[element]} "
-        
-        input_param['orbital_corr'] = orbital_corr_param.strip()
-        input_param['hubbard_u'] = hubbard_u_param.strip()
-
     try:
-        WriteInput(input_param, input_file)
-    except Exception as e:
-        raise RuntimeError("Error occured during writing modified INPUT file")
+        input_file = os.path.join(abacusjob_dir, "INPUT")
+        if dft_plus_u_settings is not None:
+            stru_file = os.path.join(abacusjob_dir, "STRU")
+        if not os.path.isfile(input_file):
+            raise FileNotFoundError(f"INPUT file {input_file} does not exist.")
 
-    return {'abacusjob_dir': abacusjob_dir,
-            'input_content': input_param}
+        # Update simple keys and their values
+        input_param = ReadInput(input_file)
+        if extra_input is not None:
+            for key, value in extra_input.items():
+                input_param[key] = value
+    
+        # Remove keys
+        if remove_input is not None:
+            for param in remove_input:
+                input_param.pop(param,None)
+
+        # DFT+U settings
+        main_group_elements = [
+        "H", "He", 
+        "Li", "Be", "B", "C", "N", "O", "F", "Ne",
+        "Na", "Mg", "Al", "Si", "P", "S", "Cl", "Ar",
+        "K", "Ca", "Ga", "Ge", "As", "Se", "Br", "Kr",
+        "Rb", "Sr", "In", "Sn", "Sb", "Te", "I", "Xe",
+        "Cs", "Ba", "Tl", "Pb", "Bi", "Po", "At", "Rn",
+        "Fr", "Ra", "Nh", "Fl", "Mc", "Lv", "Ts", "Og" ]
+        transition_metals = [
+        "Sc", "Ti", "V", "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn",
+        "Y", "Zr", "Nb", "Mo", "Tc", "Ru", "Rh", "Pd", "Ag", "Cd",
+        "Hf", "Ta", "W", "Re", "Os", "Ir", "Pt", "Au", "Hg",
+        "Rf", "Db", "Sg", "Bh", "Hs", "Mt", "Ds", "Rg", "Cn"]
+        lanthanides_and_acnitides = [
+        "La", "Ce", "Pr", "Nd", "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu",
+        "Ac", "Th", "Pa", "U", "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr"]
+
+        orbital_corr_map = {'p': 1, 'd': 2, 'f': 3}
+        if dft_plus_u_settings is not None:
+            input_param['dft_plus_u'] = 1
+
+            stru = AbacusStru.ReadStru(stru_file)
+            elements = stru.get_element(number=False,total=False)
+
+            orbital_corr_param, hubbard_u_param = '', ''
+            for element in elements:
+                if element not in dft_plus_u_settings:
+                    orbital_corr_param += ' -1 '
+                    hubbard_u_param += ' 0 '
+                else:
+                    if type(dft_plus_u_settings[element]) is not float: # orbital_corr and hubbard_u are provided
+                        orbital_corr = orbital_corr_map[dft_plus_u_settings[element][0]]
+                        orbital_corr_param += f" {orbital_corr} "
+                        hubbard_u_param += f" {dft_plus_u_settings[element][1]} "
+                    else: #Only hubbard_u is provided, use default orbital_corr
+                        if element in main_group_elements:
+                            default_orb_corr = 1
+                        elif element in transition_metals:
+                            default_orb_corr = 2
+                        elif element in lanthanides_and_acnitides:
+                            default_orb_corr = 3
+
+                        orbital_corr_param += f" {default_orb_corr} "
+                        hubbard_u_param += f" {dft_plus_u_settings[element]} "
+
+            input_param['orbital_corr'] = orbital_corr_param.strip()
+            input_param['hubbard_u'] = hubbard_u_param.strip()
+
+        try:
+            WriteInput(input_param, input_file)
+        except Exception as e:
+            raise RuntimeError("Error occured during writing modified INPUT file")
+
+        return {'abacusjob_dir': abacusjob_dir,
+                'input_content': input_param}
+    except Exception as e:
+        return {'abacusjob_dir': Path(''),
+                'input_content': None,
+                'message': f"Modify ABACUS INPUT file failed: {e}"}
 
 @mcp.tool()
 def abacus_modify_stru(
@@ -494,90 +525,96 @@ def abacus_modify_stru(
           or length of fixed_atoms_idx and movable_coords are not equal, or element in movable_coords are not a list with 3 bool elements
         KeyError: If pseudopotential or orbital are not provided for a element
     """
-    stru_file = os.path.join(abacusjob_dir, "STRU")
-    if os.path.isfile(stru_file):
-        stru = AbacusStru.ReadStru(stru_file)
-    else:
-        raise ValueError(f"{stru_file} is not path of a file")
-    
-    # Set pp and orb
-    elements = stru.get_element(number=False,total=False)
-    if pp is not None:
-        pplist = []
-        for element in elements:
-            if element in pp:
-                pplist.append(pp[element])
-            else:
-                raise KeyError(f"Pseudopotential for element {element} is not provided")
-        
-        stru.set_pp(pplist)
+    try:
+        stru_file = os.path.join(abacusjob_dir, "STRU")
+        if os.path.isfile(stru_file):
+            stru = AbacusStru.ReadStru(stru_file)
+        else:
+            raise ValueError(f"{stru_file} is not path of a file")
 
-    if orb is not None:
-        orb_list = []
-        for element in elements:
-            if element in orb:
-                orb_list.append(orb[element])
-            else:
-                raise KeyError(f"Orbital for element {element} is not provided")
-
-        stru.set_orb(orb_list)
-    
-    # Set cell
-    if cell is not None:
-        if len(cell) != 3 or any(len(c) != 3 for c in cell):
-            raise ValueError("Cell should be a list of 3 lists, each containing 3 floats")
-
-        if np.allclose(np.linalg.det(np.array(cell)), 0) is True:
-            raise ValueError("Cell cannot be a singular matrix, please provide a valid cell")
-        if coord_change_type == "scale":
-            stru.set_cell(cell, bohr=False)
-        elif coord_change_type == "original":
-            stru.set_cell(cell, bohr=False, change_coord=False)
-        else:
-            raise ValueError("coord_change_type should be 'scale' or 'original'")
-    
-    # Set atomic magmom for every atom
-    natoms = len(stru.get_coord())
-    if initial_magmoms is not None:
-        if len(initial_magmoms) == natoms:
-            stru.set_atommag(initial_magmoms)
-        else:
-            raise ValueError("The dimension of given initial magmoms is not equal with number of atoms")
-    if angle1 is not None and angle2 is not None:
-        if len(initial_magmoms) == natoms:
-            stru.set_angle1(angle1)
-        else:
-            raise ValueError("The dimension of given angle1 of initial magmoms is not equal with number of atoms")
-        
-        if len(initial_magmoms) == natoms:
-            stru.set_angle2(angle2)
-        else:
-            raise ValueError("The dimension of given angle2 of initial magmoms is not equal with number of atoms")
-    
-    # Set atom fixations
-    # Atom fixations in fix_atoms and movable_coors will be applied to original atom fixation
-    if fix_atoms_idx is not None:
-        atom_move = stru.get_move()
-        for fix_idx, atom_idx in enumerate(fix_atoms_idx):
-            if fix_idx < 0 or fix_idx >= natoms:
-                raise ValueError("Given index of atoms to be fixed is not a integer >= 0 or < natoms")
-            
-            if len(fix_atoms_idx) == len(movable_coords):
-                if len(movable_coords[fix_idx]) == 3:
-                    atom_move[atom_idx] = movable_coords[fix_idx]
+        # Set pp and orb
+        elements = stru.get_element(number=False,total=False)
+        if pp is not None:
+            pplist = []
+            for element in elements:
+                if element in pp:
+                    pplist.append(pp[element])
                 else:
-                    raise ValueError("Elements of movable_coords should be a list with 3 bool elements")
-            else:
-                raise ValueError("Length of fix_atoms_idx and movable_coords should be equal")
+                    raise KeyError(f"Pseudopotential for element {element} is not provided")
 
-        stru._move = atom_move
-    
-    stru.write(stru_file)
-    stru_content = Path(stru_file).read_text(encoding='utf-8')
-    
-    return {'abacusjob_dir': Path(abacusjob_dir).absolute(),
-            'stru_content': stru_content 
-            }
+            stru.set_pp(pplist)
+
+        if orb is not None:
+            orb_list = []
+            for element in elements:
+                if element in orb:
+                    orb_list.append(orb[element])
+                else:
+                    raise KeyError(f"Orbital for element {element} is not provided")
+
+            stru.set_orb(orb_list)
+
+        # Set cell
+        if cell is not None:
+            if len(cell) != 3 or any(len(c) != 3 for c in cell):
+                raise ValueError("Cell should be a list of 3 lists, each containing 3 floats")
+
+            if np.allclose(np.linalg.det(np.array(cell)), 0) is True:
+                raise ValueError("Cell cannot be a singular matrix, please provide a valid cell")
+            if coord_change_type == "scale":
+                stru.set_cell(cell, bohr=False)
+            elif coord_change_type == "original":
+                stru.set_cell(cell, bohr=False, change_coord=False)
+            else:
+                raise ValueError("coord_change_type should be 'scale' or 'original'")
+
+        # Set atomic magmom for every atom
+        natoms = len(stru.get_coord())
+        if initial_magmoms is not None:
+            if len(initial_magmoms) == natoms:
+                stru.set_atommag(initial_magmoms)
+            else:
+                raise ValueError("The dimension of given initial magmoms is not equal with number of atoms")
+        if angle1 is not None and angle2 is not None:
+            if len(initial_magmoms) == natoms:
+                stru.set_angle1(angle1)
+            else:
+                raise ValueError("The dimension of given angle1 of initial magmoms is not equal with number of atoms")
+
+            if len(initial_magmoms) == natoms:
+                stru.set_angle2(angle2)
+            else:
+                raise ValueError("The dimension of given angle2 of initial magmoms is not equal with number of atoms")
+
+        # Set atom fixations
+        # Atom fixations in fix_atoms and movable_coors will be applied to original atom fixation
+        if fix_atoms_idx is not None:
+            atom_move = stru.get_move()
+            for fix_idx, atom_idx in enumerate(fix_atoms_idx):
+                if fix_idx < 0 or fix_idx >= natoms:
+                    raise ValueError("Given index of atoms to be fixed is not a integer >= 0 or < natoms")
+
+                if len(fix_atoms_idx) == len(movable_coords):
+                    if len(movable_coords[fix_idx]) == 3:
+                        atom_move[atom_idx] = movable_coords[fix_idx]
+                    else:
+                        raise ValueError("Elements of movable_coords should be a list with 3 bool elements")
+                else:
+                    raise ValueError("Length of fix_atoms_idx and movable_coords should be equal")
+
+            stru._move = atom_move
+
+        stru.write(stru_file)
+        stru_content = Path(stru_file).read_text(encoding='utf-8')
+
+        return {'abacusjob_dir': Path(abacusjob_dir).absolute(),
+                'stru_content': stru_content 
+                }
+    except Exception as e:
+        return {'abacusjob_dir': Path(''),
+                'stru_content': None,
+                'message': f"Modify ABACUS STRU file failed: {e}"
+                }
 
 @mcp.tool()
 def abacus_collect_data(
@@ -692,24 +729,28 @@ def abacus_collect_data(
         IOError: If read abacus result failed
         RuntimeError: If error occured during collectring data using abacustest
     """
-    abacusjob = Path(abacusjob)
     try:
-        abacusresult = RESULT(fmt="abacus", path=abacusjob)
-    except:
-        raise IOError("Read abacus result failed")
-    
-    collected_metrics = {}
-    for metric in metrics:
+        abacusjob = Path(abacusjob)
         try:
-            collected_metrics[metric] = abacusresult[metric]
-        except Exception as e:
-            raise RuntimeError(f"Error during collecting {metric}")
-    
-    metric_file_path = os.path.join(abacusjob, "metrics.json")
-    with open(metric_file_path, "w", encoding="UTF-8") as f:
-        json.dump(collected_metrics, f, indent=4)
-    
-    return {'collected_metrics': collected_metrics}
+            abacusresult = RESULT(fmt="abacus", path=abacusjob)
+        except:
+            raise IOError("Read abacus result failed")
+
+        collected_metrics = {}
+        for metric in metrics:
+            try:
+                collected_metrics[metric] = abacusresult[metric]
+            except Exception as e:
+                raise RuntimeError(f"Error during collecting {metric}")
+
+        metric_file_path = os.path.join(abacusjob, "metrics.json")
+        with open(metric_file_path, "w", encoding="UTF-8") as f:
+            json.dump(collected_metrics, f, indent=4)
+
+        return {'collected_metrics': collected_metrics}
+    except Exception as e:
+        return {'collected_metrics': None,
+                'message': f'Collectiong results from ABACUS output files failed: {e}'}
 
 @mcp.tool()
 def run_abacus_onejob(
@@ -722,7 +763,12 @@ def run_abacus_onejob(
     Returns:
         the collected metrics from the ABACUS job.
     """
-    run_abacus(abacusjob)
+    try:
+        run_abacus(abacusjob)
 
-    return {'abacusjob_dir': abacusjob,
-            'metrics': abacus_collect_data(abacusjob)}
+        return {'abacusjob_dir': abacusjob,
+                'metrics': abacus_collect_data(abacusjob)}
+    except Exception as e:
+        return {'abacusjob_dir': Path(''),
+                'metrics': None,
+                'message': f"Run ABACUS using given input file failed: {e}"}

--- a/src/abacusagent/modules/abacus.py
+++ b/src/abacusagent/modules/abacus.py
@@ -79,16 +79,13 @@ def generate_bulk_structure(element: str,
 
         if crystal_structure in ['fcc', 'bcc', 'diamond', 'zincblende']:
             special_params['cubic'] = cubic
-        try:
-            structure = bulk(
-                name=element,
-                crystalstructure=crystal_structure,
-                a=a,
-                **special_params
-            )
-        except Exception as e:
-            raise ValueError(f"Generate structure failed: {str(e)}") from e
 
+        structure = bulk(
+            name=element,
+            crystalstructure=crystal_structure,
+            a=a,
+            **special_params
+        )
         work_path = generate_work_path(create=True)
 
         if file_format == "cif":
@@ -113,7 +110,7 @@ def generate_bulk_structure(element: str,
             "message": f"Generating bulk structure failed: {e}"
         }
 
-@mcp.tool()
+#@mcp.tool()
 def generate_bulk_structure_from_wyckoff_position(
     a: float,
     b: float,
@@ -468,10 +465,7 @@ def abacus_modify_input(
             input_param['orbital_corr'] = orbital_corr_param.strip()
             input_param['hubbard_u'] = hubbard_u_param.strip()
 
-        try:
-            WriteInput(input_param, input_file)
-        except Exception as e:
-            raise RuntimeError("Error occured during writing modified INPUT file")
+        WriteInput(input_param, input_file)
 
         return {'abacusjob_dir': abacusjob_dir,
                 'input_content': input_param}

--- a/src/abacusagent/modules/abacus.py
+++ b/src/abacusagent/modules/abacus.py
@@ -99,14 +99,10 @@ def generate_bulk_structure(element: str,
 
         return {
             "structure_file": Path(structure_file).absolute(),
-            "cell": structure.get_cell().tolist(),
-            "coordinate": structure.get_positions().tolist()
         }
     except Exception as e:
         return {
             "structure_file": None,
-            "cell": None,
-            "coordinate": None,
             "message": f"Generating bulk structure failed: {e}"
         }
 
@@ -154,7 +150,7 @@ def generate_bulk_structure_from_wyckoff_position(
 
         return {"structure_file": crys_file_name}
     except Exception as e:
-        return {"structure_file": Path(''),
+        return {"structure_file": None,
                 "message": f"Generating bulk structure from Wyckoff position failed: {e}"}
 
 @mcp.tool()
@@ -224,14 +220,10 @@ def generate_molecule_structure(
 
         return {
             "structure_file": Path(stru_file_path).absolute(),
-            "cell": atoms.get_cell().tolist(),
-            "coordinate": atoms.get_positions().tolist()
         }
     except Exception as e:
         return {
             "structure_file": None,
-            "cell": None,
-            "coordinate": None,
             "message": f"Generating molecule structure failed: {e}"
         }
 
@@ -337,12 +329,10 @@ def abacus_prepare(
         os.chdir(pwd)
 
         return {"job_path": job_path,
-                "input_content": input_content,
-                "input_files": input_files}
+                "input_content": input_content}
     except Exception as e:
         return {"job_path": None,
                 "input_content": None,
-                "input_files": None,
                 "message": f"Prepare ABACUS input files from given structure failed: {e}"}
 
 #@mcp.tool()
@@ -761,6 +751,6 @@ def run_abacus_onejob(
         return {'abacusjob_dir': abacusjob,
                 'metrics': abacus_collect_data(abacusjob)}
     except Exception as e:
-        return {'abacusjob_dir': Path(''),
+        return {'abacusjob_dir': None,
                 'metrics': None,
                 'message': f"Run ABACUS using given input file failed: {e}"}

--- a/src/abacusagent/modules/bader.py
+++ b/src/abacusagent/modules/bader.py
@@ -261,33 +261,42 @@ def abacus_badercharge_run(
         - bader_workpath: Absolute path to the Bader analysis work directory.
         - cube_file: Absolute path to the cube file used for Bader analysis.
     """
+    try:
+        # Run ABACUS to calculate charge density
+        results = calculate_charge_densities_with_abacus(jobdir)
+        abacus_jobpath = results["work_path"]
+        fcube = results["cube_files"]
 
-    # Run ABACUS to calculate charge density
-    results = calculate_charge_densities_with_abacus(jobdir)
-    abacus_jobpath = results["work_path"]
-    fcube = results["cube_files"]
-    
-    stru = AbacusStru.ReadStru(os.path.join(abacus_jobpath, "STRU"))
-    if stru is not None:
-        atom_labels = stru.get_label(total=True)
-    else:
-        atom_labels = None
-    
-    # Postprocess the charge density to obtain Bader charges
-    bader_results = postprocess_charge_densities(fcube)
-    original_atom_electrons = abacus_collect_data(Path(abacus_jobpath),
-                                                  metrics=['nelec_dict'])['collected_metrics']['nelec_dict']
+        stru = AbacusStru.ReadStru(os.path.join(abacus_jobpath, "STRU"))
+        if stru is not None:
+            atom_labels = stru.get_label(total=True)
+        else:
+            atom_labels = None
 
-    for i in range(len(bader_results['bader_charges'])):
-        bader_results["bader_charges"][i] = original_atom_electrons.get(atom_labels[i], 0) - bader_results["bader_charges"][i]
-    
-    return {
-        "bader_charges": bader_results["bader_charges"],
-        "atom_labels": atom_labels,
-        "abacus_workpath": Path(abacus_jobpath).absolute(),
-        "bader_workpath": Path(bader_results["work_path"]).absolute(),
-        "cube_file": Path(bader_results["cube_file"]).absolute()
-    }
+        # Postprocess the charge density to obtain Bader charges
+        bader_results = postprocess_charge_densities(fcube)
+        original_atom_electrons = abacus_collect_data(Path(abacus_jobpath),
+                                                      metrics=['nelec_dict'])['collected_metrics']['nelec_dict']
+
+        for i in range(len(bader_results['bader_charges'])):
+            bader_results["bader_charges"][i] = original_atom_electrons.get(atom_labels[i], 0) - bader_results["bader_charges"][i]
+
+        return {
+            "bader_charges": bader_results["bader_charges"],
+            "atom_labels": atom_labels,
+            "abacus_workpath": Path(abacus_jobpath).absolute(),
+            "bader_workpath": Path(bader_results["work_path"]).absolute(),
+            "cube_file": Path(bader_results["cube_file"]).absolute()
+        }
+    except Exception as e:
+        return {
+            "bader_charges": None,
+            "atom_labels": None,
+            "abacus_workpath": Path(''),
+            "bader_workpath": Path(''),
+            "cube_file": Path(''),
+            "message": f"Calculating Bader charge failed: {e}"
+        }
 
 class TestBaderChargeWorkflow(unittest.TestCase):
     

--- a/src/abacusagent/modules/bader.py
+++ b/src/abacusagent/modules/bader.py
@@ -292,9 +292,9 @@ def abacus_badercharge_run(
         return {
             "bader_charges": None,
             "atom_labels": None,
-            "abacus_workpath": Path(''),
-            "bader_workpath": Path(''),
-            "cube_file": Path(''),
+            "abacus_workpath": None,
+            "bader_workpath": None,
+            "cube_file": None,
             "message": f"Calculating Bader charge failed: {e}"
         }
 

--- a/src/abacusagent/modules/band.py
+++ b/src/abacusagent/modules/band.py
@@ -405,7 +405,7 @@ def abacus_cal_band(abacus_inputs_path: Path,
         else:
             raise ValueError(f"Calculation mode {mode} not in ('pyatb', 'nscf')")
     except Exception as e:
-            return {'band_gap': plot_output['band_gap'],
-                    'band_calc_dir': Path(work_path).absolute(),
-                    'band_picture': Path(plot_output['band_picture']).absolute(),
-                    'messsage': f"Calculating band failed: {e}"}
+        return {'band_gap': None,
+                'band_calc_dir': None,
+                'band_picture': None,
+                'messsage': f"Calculating band failed: {e}"}

--- a/src/abacusagent/modules/band.py
+++ b/src/abacusagent/modules/band.py
@@ -343,6 +343,7 @@ def abacus_plot_band_pyatb(band_calc_path: Path,
 
 @mcp.tool()
 def abacus_cal_band(abacus_inputs_path: Path,
+                    mode: Literal["nscf", "pyatb"] = "pyatb",
                     energy_min: float = -10,
                     energy_max: float = 10
 ) -> Dict[str, float|str]:
@@ -351,6 +352,8 @@ def abacus_cal_band(abacus_inputs_path: Path,
     PYATB or ABACUS NSCF calculation will be used according to parameters in INPUT.
     Args:
         abacusjob_dir (str): Absolute path to a directory containing the INPUT, STRU, KPT, and pseudopotential or orbital files.
+        mode: Method used to plot band. Should be `pyatb` or `nscf`. `nscf` means using `nscf` calculation in ABACUS, `pyatb` means using PYATB
+            to plot the band.
         energy_min (float): Lower bound of $E - E_F$ in the plotted band.
         energy_max (float): Upper bound of $E - E_F$ in the plotted band.
     Returns:
@@ -366,7 +369,7 @@ def abacus_cal_band(abacus_inputs_path: Path,
                                                                       new_stru_file=original_stru_file,
                                                                       kpt_file=band_kpt_file)
 
-        scf_output = property_calculation_scf(abacus_inputs_path)
+        scf_output = property_calculation_scf(abacus_inputs_path, mode)
         work_path, mode = scf_output["work_path"], scf_output["mode"]
         if mode == 'pyatb':
             # Obtain band using PYATB

--- a/src/abacusagent/modules/cube.py
+++ b/src/abacusagent/modules/cube.py
@@ -57,8 +57,8 @@ def abacus_cal_elf(abacusjob_dir: Path):
         }
     except Exception as e:
         return {
-            "work_path": Path(''),
-            "elf_file": Path(''),
+            "work_path": None,
+            "elf_file": None,
             'message': f"Calculating electron localization function failed: {e}"
         }
 
@@ -217,8 +217,8 @@ def abacus_cal_charge_density_difference(
         return {'work_path': Path(work_path).absolute(),
                 'charge_density_difference_cube_file': chg_dens_diff_cube_file}
     except Exception as e:
-        return {'work_path': Path(''),
-                'charge_density_difference_cube_file': Path(''),
+        return {'work_path': None,
+                'charge_density_difference_cube_file': None,
                 'message': f'Calculaing charge density difference failed: {e}'}
 
 @mcp.tool()
@@ -264,6 +264,6 @@ def abacus_cal_spin_density(
         return {'work_path': Path(work_path).absolute(),
                 'spin_density': Path(spin_density_file).absolute()}
     except Exception as e:
-        return {'work_path': Path(work_path).absolute(),
-                'spin_density': Path(spin_density_file).absolute(),
+        return {'work_path': None,
+                'spin_density': None,
                 'message': f"Calculating spin density failed: {e}"}

--- a/src/abacusagent/modules/cube.py
+++ b/src/abacusagent/modules/cube.py
@@ -32,28 +32,35 @@ def abacus_cal_elf(abacusjob_dir: Path):
         ValueError: If the nspin in INPUT is not 1 or 2.
         FileNotFoundError: If the ELF file is not found in the output directory.
     """
-    work_path = Path(generate_work_path()).absolute()
-    link_abacusjob(src=abacusjob_dir, dst=work_path, copy_files=["INPUT"])
+    try:
+        work_path = Path(generate_work_path()).absolute()
+        link_abacusjob(src=abacusjob_dir, dst=work_path, copy_files=["INPUT"])
 
-    input_params = ReadInput(os.path.join(work_path, "INPUT"))
-    if input_params.get('nspin', 1) not in [1, 2]:
-        raise ValueError("ELF calculation only supports nspin=1 or nspin=2.")
-    
-    input_params['calculation'] = 'scf'
-    input_params['out_elf'] = 1
-    WriteInput(input_params, os.path.join(work_path, "INPUT"))
+        input_params = ReadInput(os.path.join(work_path, "INPUT"))
+        if input_params.get('nspin', 1) not in [1, 2]:
+            raise ValueError("ELF calculation only supports nspin=1 or nspin=2.")
 
-    run_abacus(work_path)
-    
-    suffix = input_params.get('suffix', 'ABACUS')
-    elf_file = os.path.join(work_path, f'OUT.{suffix}/ELF.cube')
-    if not os.path.exists(elf_file):
-        raise FileNotFoundError(f"ELF file not found in {work_path}")
+        input_params['calculation'] = 'scf'
+        input_params['out_elf'] = 1
+        WriteInput(input_params, os.path.join(work_path, "INPUT"))
 
-    return {
-        "work_path": Path(work_path).absolute(),
-        "elf_file": Path(elf_file).absolute()
-    }
+        run_abacus(work_path)
+
+        suffix = input_params.get('suffix', 'ABACUS')
+        elf_file = os.path.join(work_path, f'OUT.{suffix}/ELF.cube')
+        if not os.path.exists(elf_file):
+            raise FileNotFoundError(f"ELF file not found in {work_path}")
+
+        return {
+            "work_path": Path(work_path).absolute(),
+            "elf_file": Path(elf_file).absolute()
+        }
+    except Exception as e:
+        return {
+            "work_path": Path(''),
+            "elf_file": Path(''),
+            'message': f"Calculating electron localization function failed: {e}"
+        }
 
 def get_subsys_pp_orb(stru: AbacusStru,
                       subsys_atom_index: List[int]
@@ -128,86 +135,91 @@ def abacus_cal_charge_density_difference(
     Raises:
         FileNotFoundError: If the charge density difference file is not found in the output directory.
     """
-    work_path = Path(generate_work_path()).absolute()
-    full_system_jobpath = os.path.join(work_path, "full_system")
-    subsys1_jobpath = os.path.join(work_path, 'subsys1')
-    subsys2_jobpath = os.path.join(work_path, 'subsys2')
-    link_abacusjob(src=abacusjob_dir, dst=full_system_jobpath, copy_files=["INPUT", "STRU"], exclude_directories=True)
-    link_abacusjob(src=abacusjob_dir, dst=subsys1_jobpath, copy_files=["INPUT", "STRU"], exclude_directories=True)
-    link_abacusjob(src=abacusjob_dir, dst=subsys2_jobpath, copy_files=["INPUT", "STRU"], exclude_directories=True)
+    try:
+        work_path = Path(generate_work_path()).absolute()
+        full_system_jobpath = os.path.join(work_path, "full_system")
+        subsys1_jobpath = os.path.join(work_path, 'subsys1')
+        subsys2_jobpath = os.path.join(work_path, 'subsys2')
+        link_abacusjob(src=abacusjob_dir, dst=full_system_jobpath, copy_files=["INPUT", "STRU"], exclude_directories=True)
+        link_abacusjob(src=abacusjob_dir, dst=subsys1_jobpath, copy_files=["INPUT", "STRU"], exclude_directories=True)
+        link_abacusjob(src=abacusjob_dir, dst=subsys2_jobpath, copy_files=["INPUT", "STRU"], exclude_directories=True)
 
-    input_params = ReadInput(os.path.join(full_system_jobpath, "INPUT"))
-    full_system_stru_file = os.path.join(full_system_jobpath, input_params.get('stru_file', 'STRU'))
-    full_system_stru = AbacusStru.ReadStru(full_system_stru_file)
+        input_params = ReadInput(os.path.join(full_system_jobpath, "INPUT"))
+        full_system_stru_file = os.path.join(full_system_jobpath, input_params.get('stru_file', 'STRU'))
+        full_system_stru = AbacusStru.ReadStru(full_system_stru_file)
 
-    # Prepare labels, coordinates, pp and orbital settings needed to generate STRU file for every subsystems
-    subsys2_atom_index = [i for i in range(full_system_stru.get_natoms()) if i not in subsys1_atom_index]
-    if len(subsys1_atom_index) is None:
-        raise ValueError("Subsystem 1 have no atoms! Aborting calculating charge density difference")
-    if len(subsys2_atom_index) is None:
-        raise ValueError("Subsystem 2 have no atoms! Aborting calculating charge density difference")
+        # Prepare labels, coordinates, pp and orbital settings needed to generate STRU file for every subsystems
+        subsys2_atom_index = [i for i in range(full_system_stru.get_natoms()) if i not in subsys1_atom_index]
+        if len(subsys1_atom_index) is None:
+            raise ValueError("Subsystem 1 have no atoms! Aborting calculating charge density difference")
+        if len(subsys2_atom_index) is None:
+            raise ValueError("Subsystem 2 have no atoms! Aborting calculating charge density difference")
 
-    subsys1_stru_file = os.path.join(work_path, f"subsys1/{input_params.get('stru_file', 'STRU')}")
-    subsys2_stru_file = os.path.join(work_path, f"subsys2/{input_params.get('stru_file', 'STRU')}")
-    subsys1_pp, subsys1_orb, subsys1_label = get_subsys_pp_orb(full_system_stru, subsys1_atom_index)
-    subsys2_pp, subsys2_orb, subsys2_label = get_subsys_pp_orb(full_system_stru, subsys2_atom_index)
+        subsys1_stru_file = os.path.join(work_path, f"subsys1/{input_params.get('stru_file', 'STRU')}")
+        subsys2_stru_file = os.path.join(work_path, f"subsys2/{input_params.get('stru_file', 'STRU')}")
+        subsys1_pp, subsys1_orb, subsys1_label = get_subsys_pp_orb(full_system_stru, subsys1_atom_index)
+        subsys2_pp, subsys2_orb, subsys2_label = get_subsys_pp_orb(full_system_stru, subsys2_atom_index)
 
-    subsys1_coord, subsys2_coord = [], []
-    full_system_stru_coord = full_system_stru.get_coord()
-    for i in range(full_system_stru.get_natoms()):
-        if i in subsys1_atom_index:
-            subsys1_coord.append(full_system_stru_coord[i])
-        elif i in subsys2_atom_index:
-            subsys2_coord.append(full_system_stru_coord[i])
-        else:
-            raise ValueError(f"Atom {i} does not belong to neither subsystem1 nor subsystem2")
-    
-    subsys1_stru = AbacusStru(label=subsys1_label,
-                              cell=full_system_stru.get_cell(),
-                              coord=subsys1_coord,
-                              lattice_constant=full_system_stru.get_stru()['lat'],
-                              pp=subsys1_pp,
-                              orb=subsys1_orb,
-                              cartesian=True)
-    subsys1_stru.write(subsys1_stru_file)
+        subsys1_coord, subsys2_coord = [], []
+        full_system_stru_coord = full_system_stru.get_coord()
+        for i in range(full_system_stru.get_natoms()):
+            if i in subsys1_atom_index:
+                subsys1_coord.append(full_system_stru_coord[i])
+            elif i in subsys2_atom_index:
+                subsys2_coord.append(full_system_stru_coord[i])
+            else:
+                raise ValueError(f"Atom {i} does not belong to neither subsystem1 nor subsystem2")
 
-    subsys2_stru = AbacusStru(label=subsys2_label,
-                              cell=full_system_stru.get_cell(),
-                              coord=subsys2_coord,
-                              lattice_constant=full_system_stru.get_stru()['lat'],
-                              pp=subsys2_pp,
-                              orb=subsys2_orb,
-                              cartesian=True)
-    subsys2_stru.write(subsys2_stru_file)
+        subsys1_stru = AbacusStru(label=subsys1_label,
+                                  cell=full_system_stru.get_cell(),
+                                  coord=subsys1_coord,
+                                  lattice_constant=full_system_stru.get_stru()['lat'],
+                                  pp=subsys1_pp,
+                                  orb=subsys1_orb,
+                                  cartesian=True)
+        subsys1_stru.write(subsys1_stru_file)
 
-    # Modify INPUT file to output cube file needed for calculating charge density difference
-    input_params['calculation'] = 'scf'
-    input_params['out_chg'] = '1'
-    
-    WriteInput(input_params, os.path.join(full_system_jobpath, 'INPUT'))
-    run_abacus(full_system_jobpath)
-    WriteInput(input_params, os.path.join(subsys1_jobpath, 'INPUT'))
-    run_abacus(subsys1_jobpath)
-    WriteInput(input_params, os.path.join(subsys2_jobpath, 'INPUT'))
-    run_abacus(subsys2_jobpath)
+        subsys2_stru = AbacusStru(label=subsys2_label,
+                                  cell=full_system_stru.get_cell(),
+                                  coord=subsys2_coord,
+                                  lattice_constant=full_system_stru.get_stru()['lat'],
+                                  pp=subsys2_pp,
+                                  orb=subsys2_orb,
+                                  cartesian=True)
+        subsys2_stru.write(subsys2_stru_file)
 
-    # Generate cube file containing charge density difference
-    full_system_chgfile = os.path.join(full_system_jobpath, f"OUT.{input_params.get('suffix', 'ABACUS')}/SPIN1_CHG.cube")
+        # Modify INPUT file to output cube file needed for calculating charge density difference
+        input_params['calculation'] = 'scf'
+        input_params['out_chg'] = '1'
 
-    full_system_chg = get_total_charge_density(full_system_jobpath)
-    subsys1_chg = get_total_charge_density(subsys1_jobpath)
-    subsys2_chg = get_total_charge_density(subsys2_jobpath)
-    
-    sum_subsys_chg = read_gaussian_cube(full_system_chgfile)  # Fetch the data structure. The volumeric data will be replaced later
-    chg_density_difference = read_gaussian_cube(full_system_chgfile) # Fetch the data structure. The volumeric data will be replaced later
-    sum_subsys_chg['data'] = axpy(subsys1_chg['data'], subsys2_chg['data'])
-    chg_density_difference['data'] = axpy(sum_subsys_chg['data'], full_system_chg['data'], alpha=1.0, beta=-1.0)
+        WriteInput(input_params, os.path.join(full_system_jobpath, 'INPUT'))
+        run_abacus(full_system_jobpath)
+        WriteInput(input_params, os.path.join(subsys1_jobpath, 'INPUT'))
+        run_abacus(subsys1_jobpath)
+        WriteInput(input_params, os.path.join(subsys2_jobpath, 'INPUT'))
+        run_abacus(subsys2_jobpath)
 
-    chg_dens_diff_cube_file = Path(os.path.join(work_path, 'chg_density_diff.cube')).absolute()
-    write_gaussian_cube(chg_density_difference, chg_dens_diff_cube_file)
+        # Generate cube file containing charge density difference
+        full_system_chgfile = os.path.join(full_system_jobpath, f"OUT.{input_params.get('suffix', 'ABACUS')}/SPIN1_CHG.cube")
 
-    return {'work_path': Path(work_path).absolute(),
-            'charge_density_difference_cube_file': chg_dens_diff_cube_file}
+        full_system_chg = get_total_charge_density(full_system_jobpath)
+        subsys1_chg = get_total_charge_density(subsys1_jobpath)
+        subsys2_chg = get_total_charge_density(subsys2_jobpath)
+
+        sum_subsys_chg = read_gaussian_cube(full_system_chgfile)  # Fetch the data structure. The volumeric data will be replaced later
+        chg_density_difference = read_gaussian_cube(full_system_chgfile) # Fetch the data structure. The volumeric data will be replaced later
+        sum_subsys_chg['data'] = axpy(subsys1_chg['data'], subsys2_chg['data'])
+        chg_density_difference['data'] = axpy(sum_subsys_chg['data'], full_system_chg['data'], alpha=1.0, beta=-1.0)
+
+        chg_dens_diff_cube_file = Path(os.path.join(work_path, 'chg_density_diff.cube')).absolute()
+        write_gaussian_cube(chg_density_difference, chg_dens_diff_cube_file)
+
+        return {'work_path': Path(work_path).absolute(),
+                'charge_density_difference_cube_file': chg_dens_diff_cube_file}
+    except Exception as e:
+        return {'work_path': Path(''),
+                'charge_density_difference_cube_file': Path(''),
+                'message': f'Calculaing charge density difference failed: {e}'}
 
 @mcp.tool()
 def abacus_cal_spin_density(
@@ -227,26 +239,31 @@ def abacus_cal_spin_density(
     Raises:
         ValueError: If nspin in INPUT file is not 2.
     """
-    work_path = Path(generate_work_path()).absolute()
-    link_abacusjob(src=abacusjob_dir,dst=work_path,copy_files=["INPUT", "STRU"], exclude_directories=True)
-    input_params = ReadInput(os.path.join(work_path, 'INPUT'))
-    if input_params.get('nspin', 1) not in [2]:
-        raise ValueError('Only collinear spin-polarized calculation is supported for calculating spin density')
-    
-    input_params['calculation'] = 'scf'
-    input_params['out_chg'] = '1'
-    WriteInput(input_params, os.path.join(work_path, 'INPUT'))
+    try:
+        work_path = Path(generate_work_path()).absolute()
+        link_abacusjob(src=abacusjob_dir,dst=work_path,copy_files=["INPUT", "STRU"], exclude_directories=True)
+        input_params = ReadInput(os.path.join(work_path, 'INPUT'))
+        if input_params.get('nspin', 1) not in [2]:
+            raise ValueError('Only collinear spin-polarized calculation is supported for calculating spin density')
 
-    run_abacus(work_path)
-    chg_up_file = os.path.join(work_path, f"OUT.{input_params.get('suffix', 'ABACUS')}/SPIN1_CHG.cube")
-    chg_dn_file = os.path.join(work_path, f"OUT.{input_params.get('suffix', 'ABACUS')}/SPIN2_CHG.cube")
+        input_params['calculation'] = 'scf'
+        input_params['out_chg'] = '1'
+        WriteInput(input_params, os.path.join(work_path, 'INPUT'))
 
-    chg_up, chg_dn = read_gaussian_cube(chg_up_file), read_gaussian_cube(chg_dn_file)
-    spin_density = read_gaussian_cube(chg_up_file)
-    spin_density['data'] = axpy(chg_up['data'], chg_dn['data'], alpha=1.0, beta=-1.0)
+        run_abacus(work_path)
+        chg_up_file = os.path.join(work_path, f"OUT.{input_params.get('suffix', 'ABACUS')}/SPIN1_CHG.cube")
+        chg_dn_file = os.path.join(work_path, f"OUT.{input_params.get('suffix', 'ABACUS')}/SPIN2_CHG.cube")
 
-    spin_density_file = os.path.join(work_path, 'spin_density.cube')
-    write_gaussian_cube(spin_density, spin_density_file)
+        chg_up, chg_dn = read_gaussian_cube(chg_up_file), read_gaussian_cube(chg_dn_file)
+        spin_density = read_gaussian_cube(chg_up_file)
+        spin_density['data'] = axpy(chg_up['data'], chg_dn['data'], alpha=1.0, beta=-1.0)
 
-    return {'work_path': Path(work_path).absolute(),
-            'spin_density': Path(spin_density_file).absolute()}
+        spin_density_file = os.path.join(work_path, 'spin_density.cube')
+        write_gaussian_cube(spin_density, spin_density_file)
+
+        return {'work_path': Path(work_path).absolute(),
+                'spin_density': Path(spin_density_file).absolute()}
+    except Exception as e:
+        return {'work_path': Path(work_path).absolute(),
+                'spin_density': Path(spin_density_file).absolute(),
+                'message': f"Calculating spin density failed: {e}"}

--- a/src/abacusagent/modules/cube.py
+++ b/src/abacusagent/modules/cube.py
@@ -209,7 +209,7 @@ def abacus_cal_charge_density_difference(
         sum_subsys_chg = read_gaussian_cube(full_system_chgfile)  # Fetch the data structure. The volumeric data will be replaced later
         chg_density_difference = read_gaussian_cube(full_system_chgfile) # Fetch the data structure. The volumeric data will be replaced later
         sum_subsys_chg['data'] = axpy(subsys1_chg['data'], subsys2_chg['data'])
-        chg_density_difference['data'] = axpy(sum_subsys_chg['data'], full_system_chg['data'], alpha=1.0, beta=-1.0)
+        chg_density_difference['data'] = axpy(full_system_chg['data'], sum_subsys_chg['data'], alpha=1.0, beta=-1.0)
 
         chg_dens_diff_cube_file = Path(os.path.join(work_path, 'chg_density_diff.cube')).absolute()
         write_gaussian_cube(chg_density_difference, chg_dens_diff_cube_file)

--- a/src/abacusagent/modules/deeptb_tool.py
+++ b/src/abacusagent/modules/deeptb_tool.py
@@ -7,7 +7,7 @@ from abacusagent.init_mcp import mcp
 class ConfigResult(TypedDict):
     config_path: str
 
-@mcp.tool()
+#@mcp.tool()
 def generate_deeptb_config(
     material: Literal["Si"] = "Si",
 ) -> ConfigResult:

--- a/src/abacusagent/modules/dos.py
+++ b/src/abacusagent/modules/dos.py
@@ -374,8 +374,8 @@ def plot_pdos_species_shell(shifted_energy, orbitals, output_dir, nspin, dpi):
         ax.set_title(f'PDOS for {species}', fontsize=12, pad=10)
         ax.set_ylabel(r'States/ev${^{-1}}$', fontsize=10)
         ax.set_xlim(max(min(shifted_energy), -20), min(20, max(shifted_energy)))
-        if nspin == 1:
-            ax.set_ylim(bottom=0)
+        #if nspin == 1:
+        #    ax.set_ylim(bottom=0)
         ax.legend(fontsize=8, ncol=nspin)
         ax.grid(alpha=0.3)
         
@@ -501,7 +501,7 @@ def plot_dos(file_path: List[Path],
     plt.grid(True, alpha=0.3)
     plt.xlim(x_min, x_max)
     #plt.ylim(y_min, y_max)
-    plt.legend()
+    #plt.legend()
     
     # Save plot
     os.makedirs(os.path.dirname(output_file), exist_ok=True)

--- a/src/abacusagent/modules/dos.py
+++ b/src/abacusagent/modules/dos.py
@@ -329,6 +329,8 @@ def plot_pdos_species(shifted_energy, orbitals, output_dir, nspin, dpi):
     plt.xlabel('Energy/eV', fontsize=10)
     plt.ylabel(r'States/ev${^{-1}}$', fontsize=10)
     plt.xlim(max(min(shifted_energy), -20), min(20, max(shifted_energy)))
+    if nspin == 1:
+        plt.ylim(bottom=0)
     plt.legend(fontsize=8, ncol=nspin)
     plt.grid(alpha=0.3)
     plt.title('Projected density of States of different species')
@@ -372,6 +374,8 @@ def plot_pdos_species_shell(shifted_energy, orbitals, output_dir, nspin, dpi):
         ax.set_title(f'PDOS for {species}', fontsize=12, pad=10)
         ax.set_ylabel(r'States/ev${^{-1}}$', fontsize=10)
         ax.set_xlim(max(min(shifted_energy), -20), min(20, max(shifted_energy)))
+        if nspin == 1:
+            ax.set_ylim(bottom=0)
         ax.legend(fontsize=8, ncol=nspin)
         ax.grid(alpha=0.3)
         
@@ -442,6 +446,8 @@ def plot_pdos_species_orbital(shifted_energy, orbitals, output_dir, nspin, label
             ax.axvline(x=0, color='black', linestyle=':', linewidth=1.0)
             ax.set_title(f'PDOS for {species}-{angular_momentum}', fontsize=12, pad=10)
             ax.set_xlim(max(min(shifted_energy), -20), min(20, max(shifted_energy)))
+            if nspin == 1:
+                ax.set_ylim(bottom=0)
             ax.set_ylabel(r'States/ev${^{-1}}$', fontsize=10)
             ax.legend(fontsize=8, ncol=nspin)
             ax.grid(alpha=0.3)

--- a/src/abacusagent/modules/dos.py
+++ b/src/abacusagent/modules/dos.py
@@ -81,36 +81,41 @@ def abacus_dos_run(
             - results_nscf: Results of the NSCF calculation, including work path and normal end status.
             - fig_paths: List of paths to the generated figures for DOS and PDOS. DOS will be saved as "DOS.png" and PDOS will be saved as "species_atom_index_pdos.png" in the output directory.
     """
-    input_file = os.path.join(abacus_inputs_path, "INPUT")
-    input_params = ReadInput(input_file)
-    nspin = input_params.get("nspin", 1)
-    if nspin in [2, 4]:
-        raise ValueError("Currently DOS calculation can only be plotted using for nspin=1")
+    try:
+        input_file = os.path.join(abacus_inputs_path, "INPUT")
+        input_params = ReadInput(input_file)
+        nspin = input_params.get("nspin", 1)
+        if nspin in [2, 4]:
+            raise ValueError("Currently DOS calculation can only be plotted using for nspin=1")
 
-    metrics_scf = abacus_dos_run_scf(abacus_inputs_path)
-    metrics_nscf = abacus_dos_run_nscf(metrics_scf["scf_work_path"],
-                                       dos_edelta_ev=dos_edelta_ev,
-                                       dos_sigma=dos_sigma,
-                                       dos_scale=dos_scale, 
-                                       dos_emin_ev=dos_emin_ev,
-                                       dos_emax_ev=dos_emax_ev,
-                                       dos_nche=dos_nche)
-    
-    fig_paths = plot_dos_pdos(metrics_scf["scf_work_path"],
-                              metrics_nscf["nscf_work_path"],
-                              metrics_nscf["nscf_work_path"],
-                              nspin,
-                              pdos_mode)
+        metrics_scf = abacus_dos_run_scf(abacus_inputs_path)
+        metrics_nscf = abacus_dos_run_nscf(metrics_scf["scf_work_path"],
+                                           dos_edelta_ev=dos_edelta_ev,
+                                           dos_sigma=dos_sigma,
+                                           dos_scale=dos_scale, 
+                                           dos_emin_ev=dos_emin_ev,
+                                           dos_emax_ev=dos_emax_ev,
+                                           dos_nche=dos_nche)
 
-    return_dict = {
-        "dos_fig_path": fig_paths[0],
-        'pdos_fig_path': fig_paths[1],
-    }
+        fig_paths = plot_dos_pdos(metrics_scf["scf_work_path"],
+                                  metrics_nscf["nscf_work_path"],
+                                  metrics_nscf["nscf_work_path"],
+                                  nspin,
+                                  pdos_mode)
 
-    return_dict.update(metrics_scf)
-    return_dict.update(metrics_nscf)
+        return_dict = {
+            "dos_fig_path": fig_paths[0],
+            'pdos_fig_path': fig_paths[1],
+        }
 
-    return return_dict
+        return_dict.update(metrics_scf)
+        return_dict.update(metrics_nscf)
+
+        return return_dict
+    except Exception as e:
+        return {"dos_fig_path": Path(''),
+                "pdos_fig_path": Path(''),
+                "message": f"Calculating DOS and PDOS failed: {e}"}
 
 def abacus_dos_run_scf(abacus_inputs_path: Path,
                        force_run: bool = False) -> Dict[str, Any]:

--- a/src/abacusagent/modules/dos.py
+++ b/src/abacusagent/modules/dos.py
@@ -96,7 +96,11 @@ def abacus_dos_run(
                                        dos_emax_ev=dos_emax_ev,
                                        dos_nche=dos_nche)
     
-    fig_paths = plot_dos_pdos(metrics_scf["scf_work_path"], metrics_nscf["nscf_work_path"], nspin, pdos_mode)
+    fig_paths = plot_dos_pdos(metrics_scf["scf_work_path"],
+                              metrics_nscf["nscf_work_path"],
+                              metrics_nscf["nscf_work_path"],
+                              nspin,
+                              pdos_mode)
 
     return_dict = {
         "dos_fig_path": fig_paths[0],

--- a/src/abacusagent/modules/dos.py
+++ b/src/abacusagent/modules/dos.py
@@ -113,8 +113,8 @@ def abacus_dos_run(
 
         return return_dict
     except Exception as e:
-        return {"dos_fig_path": Path(''),
-                "pdos_fig_path": Path(''),
+        return {"dos_fig_path": None,
+                "pdos_fig_path": None,
                 "message": f"Calculating DOS and PDOS failed: {e}"}
 
 def abacus_dos_run_scf(abacus_inputs_path: Path,

--- a/src/abacusagent/modules/dos.py
+++ b/src/abacusagent/modules/dos.py
@@ -47,9 +47,9 @@ orbital_rep_map = {
 def abacus_dos_run(
     abacus_inputs_path: Path,
     pdos_mode: Literal['species', 'species+shell', 'species+orbital'] = 'species+shell',
-    dos_edelta_ev: float = None,
-    dos_sigma: float = None,
-    dos_scale: float = None,
+    dos_edelta_ev: float = 0.01,
+    dos_sigma: float = 0.07,
+    dos_scale: float = 0.01,
     dos_emin_ev: float = None,
     dos_emax_ev: float = None,
     dos_nche: int = None,
@@ -326,9 +326,9 @@ def plot_pdos_species(shifted_energy, orbitals, output_dir, nspin, dpi):
             plt.plot(shifted_energy, -pdos_data[1::2], label=f'{species_name} ' + r'$\downarrow$', linestyle='--', linewidth=1.0)
     
     plt.axvline(x=0, color='black', linestyle=':', linewidth=1.0)
-    plt.xlabel('Energy/', fontsize=10)
+    plt.xlabel('Energy/eV', fontsize=10)
     plt.ylabel(r'States/ev${^{-1}}$', fontsize=10)
-    plt.xlim(min(shifted_energy), max(shifted_energy))
+    plt.xlim(max(min(shifted_energy), -20), min(20, max(shifted_energy)))
     plt.legend(fontsize=8, ncol=nspin)
     plt.grid(alpha=0.3)
     plt.title('Projected density of States of different species')
@@ -371,7 +371,7 @@ def plot_pdos_species_shell(shifted_energy, orbitals, output_dir, nspin, dpi):
         ax.axvline(x=0, color='black', linestyle=':', linewidth=1.0)
         ax.set_title(f'PDOS for {species}', fontsize=12, pad=10)
         ax.set_ylabel(r'States/ev${^{-1}}$', fontsize=10)
-        ax.set_xlim(min(shifted_energy), max(shifted_energy))
+        ax.set_xlim(max(min(shifted_energy), -20), min(20, max(shifted_energy)))
         ax.legend(fontsize=8, ncol=nspin)
         ax.grid(alpha=0.3)
         
@@ -441,7 +441,7 @@ def plot_pdos_species_orbital(shifted_energy, orbitals, output_dir, nspin, label
                     
             ax.axvline(x=0, color='black', linestyle=':', linewidth=1.0)
             ax.set_title(f'PDOS for {species}-{angular_momentum}', fontsize=12, pad=10)
-            ax.set_xlim(min(shifted_energy), max(shifted_energy))
+            ax.set_xlim(max(min(shifted_energy), -20), min(20, max(shifted_energy)))
             ax.set_ylabel(r'States/ev${^{-1}}$', fontsize=10)
             ax.legend(fontsize=8, ncol=nspin)
             ax.grid(alpha=0.3)

--- a/src/abacusagent/modules/elastic.py
+++ b/src/abacusagent/modules/elastic.py
@@ -192,7 +192,7 @@ def abacus_cal_elastic(
         }
     except Exception as e:
         return {
-            "elastic_cal_dir": Path(''),
+            "elastic_cal_dir": None,
             "elastic_tensor": None,
             "bulk_modulus": None,
             "shear_modulus": None,

--- a/src/abacusagent/modules/eos.py
+++ b/src/abacusagent/modules/eos.py
@@ -148,9 +148,9 @@ def abacus_eos(
             "B0_deriv": B0_deriv, }
     except Exception as e:
         return {
-            "eos_work_path": Path(''),
-            "optimal_stru_abacusjob_dir": Path(''),
-            "eos_fig_path": Path(''),
+            "eos_work_path": None,
+            "optimal_stru_abacusjob_dir": None,
+            "eos_fig_path": None,
             "E0": None,
             "V0": None,
             "B0": None,

--- a/src/abacusagent/modules/md.py
+++ b/src/abacusagent/modules/md.py
@@ -185,7 +185,7 @@ def abacus_run_md(
                 'md_traj_file': convert_md_dump_to_ase_traj(Path(os.path.join(work_path, f'OUT.{suffix}/MD_dump')).absolute())}
 
     except Exception as e:
-        return {'md_work_path': Path(""),
-                'md_last_stru': Path(""),
-                'md_traj_file': Path(""),
+        return {'md_work_path': None,
+                'md_last_stru': None,
+                'md_traj_file': None,
                 "message": f"Error occured during the running md: {e}"}

--- a/src/abacusagent/modules/md.py
+++ b/src/abacusagent/modules/md.py
@@ -189,7 +189,3 @@ def abacus_run_md(
                 'md_last_stru': Path(""),
                 'md_traj_file': Path(""),
                 "message": f"Error occured during the running md: {e}"}
-
-if __name__ == '__main__':
-    get_last_md_stru(Path('/tmp/abacusagent/20250805162511/20250805162511.abacus_run_md.8eb74ccf/OUT.Si/STRU'))
-    convert_md_dump_to_ase_traj(Path('/tmp/abacusagent/20250805162511/20250805162511.abacus_run_md.8eb74ccf/OUT.Si/MD_dump'))

--- a/src/abacusagent/modules/md.py
+++ b/src/abacusagent/modules/md.py
@@ -1,0 +1,195 @@
+import os
+from pathlib import Path
+from typing import Dict, Any, List, Literal
+import re
+from pprint import pprint
+
+import numpy as np
+from ase import Atoms
+from ase.io.trajectory import TrajectoryWriter
+from abacustest.lib_prepare.abacus import ReadInput, WriteInput, AbacusStru
+
+from abacusagent.init_mcp import mcp
+from abacusagent.modules.util.comm import generate_work_path, link_abacusjob, run_abacus
+
+
+def get_last_md_stru(md_stru_outputdir: Path) -> Path:
+    if md_stru_outputdir.exists() and md_stru_outputdir.is_dir():
+        stru_files = [file.name for file in md_stru_outputdir.iterdir() if file.is_file()]
+    
+    last_frame_idx = 0
+    last_stru = Path(os.path.join(md_stru_outputdir, "STRU_MD_0")).absolute()
+    for stru_file in stru_files:
+        frame_idx = int(stru_file.split('_')[-1])
+        if frame_idx > last_frame_idx:
+            last_frame_idx = frame_idx
+            last_stru = Path(os.path.join(md_stru_outputdir, stru_file)).absolute()
+    
+    return last_stru
+
+def convert_md_dump_to_ase_traj(md_dump_path: Path, traj_filename: str="md_traj.traj"):
+    def list_to_ndarray(lst):
+        for i in range(len(lst)):
+            lst[i] = float(lst[i])
+        return np.array(lst)
+
+    md_step_line_num = []
+    with open(md_dump_path) as fin:
+        for line_number, lines in enumerate(fin, start=1):
+            if 'MDSTEP:' in lines:
+                md_step_line_num.append(line_number)
+    
+    md_steps = []
+    md_dump_file = open(md_dump_path)
+    for i in range(len(md_step_line_num)):
+        if i != len(md_step_line_num) - 1:
+            md_step_data = []
+            for j in range(md_step_line_num[i+1]-md_step_line_num[i]):
+                md_step_data.append(md_dump_file.readline())
+        else:
+            md_step_data = md_dump_file.readlines()
+        
+        for idx, line in enumerate(md_step_data):
+            if 'LATTICE_CONSTANT: ' in line:
+                words = line.split()
+                lattice_constant = float(words[1])
+            
+            if 'LATTICE_VECTORS' in line:
+                a, b, c = md_step_data[idx+1].split(), md_step_data[idx+2].split(), md_step_data[idx+3].split()
+                lattice_vectors = [a, b, c]
+                for j1 in range(len(lattice_vectors)):
+                    for j2 in range(len(lattice_vectors[j1])):
+                        lattice_vectors[j1][j2] = float(lattice_vectors[j1][j2])
+                
+                lattice_vectors = np.array(lattice_vectors) * lattice_constant
+            
+            elements, positions, forces, velocities = [], [], [], []
+            if 'INDEX    LABEL' in line:
+                for coord_line in md_step_data[idx+1:]:
+                    if coord_line.strip() != '':
+                        words = coord_line.split()
+                        elements.append(words[1])
+                        positions.append(list_to_ndarray(words[2:5]))
+                        forces.append(list_to_ndarray(words[5:8]))
+                        velocities.append(list_to_ndarray(words[8:]))
+
+            if len(elements) != 0 and len(positions) != 0:
+                md_step = Atoms(symbols = elements,
+                                positions=positions,
+                                cell=lattice_vectors,
+                                velocities=velocities)
+                md_steps.append(md_step)
+    
+    traj_writer = TrajectoryWriter(Path(os.path.join(md_dump_path.parent, traj_filename)).absolute(), mode="a", atoms=md_step)
+    for md_step in md_steps:
+        traj_writer.write(md_step)
+    traj_writer.close()
+    
+    return Path(traj_filename).absolute()
+
+@mcp.tool()
+def abacus_run_md(
+    abacusjob_dir: Path,
+    md_type: Literal['nve', 'nvt', 'npt', 'langevin'] = 'nve',
+    md_nstep: int = 10,
+    md_dt: float = 1.0,
+    md_tfirst: float = 300.0,
+    md_tlast: float = 300.0,
+    md_thermostat: Literal['nhc', 'anderson', 'berendsen', 'rescaling', 'rescale_v'] = 'nhc',
+    md_pmode: Literal['iso', 'aniso', 'tri'] = 'iso',
+    md_pcouple: Literal['none', 'xy', 'xz', 'yz', 'xyz'] = 'none',
+    md_dumpfreq: int = 1,
+    md_seed: int = -1
+) -> Dict[str, Any]:
+    """
+    Use ABACUS to do ab-initio molecular dynamics calculation.
+
+    Args:
+        abacusjob_dir (Path): Path to ABACUS input files.
+        md_type (Literal['nve', 'nvt', 'npt', 'langevin']): The algorithm to integrate the equation of motion for molecular dynamics (MD).
+            - nve: NVE ensemble with velocity Verlet algorithm.
+            - nvt: NVT ensemble.
+            - npt: Nose-Hoover style NPT ensemble.
+            - langevin: NVT ensemble with Langevin thermostat.
+        md_nstep (int): The total number of molecular dynamics steps.
+        md_dt (float): The time step used in molecular dynamics calculations. THe unit in fs.
+        md_tfirst (float): If set to larger than 0, initial velocity will be generated according to its value.
+            If unset or smaller than 0, initial velocity will try to be read from STRU file.
+        md_tlast (float): Only used in NVT/NPT simulations. If md_tlast is unset or less than zero, 
+            md_tlast is set to md_tfirst. If md_tlast is set to be different from md_tfirst, 
+            ABACUS will automatically change the temperature from md_tfirst to md_tlast
+        md_thermostat (str): Specify the temperature control method used in NVT ensemble.
+            - nhc: Nose-Hoover chain, see md_tfreq and md_tchain in detail.
+            - anderson: Anderson thermostat, see md_nraise in detail.
+            - berendsen: Berendsen thermostat, see md_nraise in detail.
+            - rescaling: velocity Rescaling method 1, see md_tolerance in detail.
+            - rescale_v: velocity Rescaling method 2, see md_nraise in detail.
+        md_pmode (str): Specify the cell fluctuation mode in NPT ensemble based on the Nose-Hoover style non-Hamiltonian equations of motion.
+            - iso: The three diagonal elements of the lattice are fluctuated isotropically.
+            - aniso: The three diagonal elements of the lattice are fluctuated anisotropically.
+            - tri: The lattice must be a lower-triangular matrix, and all six freedoms are fluctuated.
+        md_pcouple (str): The coupled lattice vectors will scale proportionally in NPT ensemble based on the Nose-Hoover style non-Hamiltonian equations of motion.
+            - none: Three lattice vectors scale independently.
+            - xyz: Lattice vectors x, y, and z scale proportionally.
+            - xy: Lattice vectors x and y scale proportionally.
+            - xz: Lattice vectors x and z scale proportionally.
+            - yz: Lattice vectors y and z scale proportionally.
+        md_dumpfreq (int): The output frequency of OUT.${suffix}/MD_dump in molecular dynamics calculations. Generally the default value 1
+            is OK. For very long ab-initio MD calculations, increasing md_dumpfreq can help reducing the size of MD_dump.
+        md_seed (int): The random seed to initialize random numbers used in molecular dynamics calculations.
+            - < 0: No srand() function is called.
+            - >= 0: The function srand(md_seed) is called.
+    Returns:
+    Raises:
+
+    """
+    try:
+        work_path = Path(generate_work_path()).absolute()
+        link_abacusjob(src=abacusjob_dir, dst=work_path, copy_files=['INPUT', 'STRU'], exclude_directories=True)
+        input_params = ReadInput(os.path.join(work_path, "INPUT"))
+
+        input_params['calculation'] = 'md'
+        for keyword, value in {
+            'md_type': md_type,
+            'md_nstep': md_nstep,
+            'md_dt': md_dt,
+            'md_tfirst': md_tfirst,
+            'md_tlast': md_tlast,
+            'md_thermostat': md_thermostat,
+            'md_pmode': md_pmode,
+            'md_pcouple': md_pcouple,
+            'md_dumpfreq': md_dumpfreq,
+            'md_seed': md_seed
+        }.items():
+            input_params[keyword] = value
+
+        if 'init_vel' in input_params.keys():
+            if md_tfirst > 0:
+                input_params.pop('init_vel')
+            else:
+                stru_file = os.path.join(work_path, input_params.get('stru_file', 'STRU'))
+                stru = AbacusStru.ReadStru(stru_file)
+                if None in stru._velocity:
+                    raise ValueError("Use md_tfirst < 0 should provide initial velocities in STRU")
+
+        if input_params['calculation'] not in ['nvt', 'npt']:
+            input_params.pop('md_tlast')
+
+        WriteInput(input_params, os.path.join(work_path, "INPUT"))
+
+        run_abacus(work_path)
+
+        suffix = input_params.get('suffix', 'ABACUS')
+        return {'md_work_path': work_path,
+                'md_last_stru': get_last_md_stru(Path(os.path.join(work_path, f'OUT.{suffix}/STRU')).absolute()),
+                'md_traj_file': convert_md_dump_to_ase_traj(Path(os.path.join(work_path, f'OUT.{suffix}/MD_dump')).absolute())}
+
+    except Exception as e:
+        return {'md_work_path': Path(""),
+                'md_last_stru': Path(""),
+                'md_traj_file': Path(""),
+                "message": f"Error occured during the running md: {e}"}
+
+if __name__ == '__main__':
+    get_last_md_stru(Path('/tmp/abacusagent/20250805162511/20250805162511.abacus_run_md.8eb74ccf/OUT.Si/STRU'))
+    convert_md_dump_to_ase_traj(Path('/tmp/abacusagent/20250805162511/20250805162511.abacus_run_md.8eb74ccf/OUT.Si/MD_dump'))

--- a/src/abacusagent/modules/phonon.py
+++ b/src/abacusagent/modules/phonon.py
@@ -141,11 +141,11 @@ def abacus_phonon_dispersion(
         }
     except Exception as e:
         return {
-            "phonon_work_path": Path(''),
-            "band_plot": Path(''),
-            "dos_plot": Path(''),
-            'band_yaml': Path(''),
-            'dos_dat_file': Path(''),
+            "phonon_work_path": None,
+            "band_plot": None,
+            "dos_plot": None,
+            'band_yaml': None,
+            'dos_dat_file': None,
             "entropy": None,
             "free_energy": None,
             "heat_capacity": None,

--- a/src/abacusagent/modules/phonon.py
+++ b/src/abacusagent/modules/phonon.py
@@ -25,7 +25,8 @@ def abacus_phonon_dispersion(
     temperature: Optional[float] = 298.15,
 ):
     """
-    Calculate phonon dispersion using Phonopy with ABACUS as the calculator.
+    Calculate phonon dispersion using Phonopy with ABACUS as the calculator. 
+    This tool function is usually followed by a cell-relax calculation (`calculation` is set to `cell-relax`). 
     Args:
         abacus_inputs_path (Path): Path to the directory containing ABACUS input files.
         supercell (List[int], optional): Supercell matrix for phonon calculations. If default value None are used,

--- a/src/abacusagent/modules/phonon.py
+++ b/src/abacusagent/modules/phonon.py
@@ -47,94 +47,109 @@ def abacus_phonon_dispersion(
             - max_frequency_THz: Maximum phonon frequency in THz.
             - max_frequency_K: Maximum phonon frequency in Kelvin.
     """
-    work_path = Path(generate_work_path()).absolute()
-    
-    input_params = ReadInput(os.path.join(abacus_inputs_path, "INPUT"))
-    stru_file = input_params.get('stru_file', "STRU")
-    stru = read(os.path.join(abacus_inputs_path, stru_file))
-    # Provide extra INPUT parameters necessary for calculating phonon dispersion
-    extra_input_params = {'calculation': 'scf',
-                          'cal_force': 1,
-                          'out_chg': 1,
-                          'init_chg': 'auto'}
-    if input_params.get('scf_thr', 1e-7) > 1e-7:
-        extra_input_params['scf_thr'] = 1e-7
-    calc = set_ase_abacus_calculator(abacus_inputs_path,
-                                     work_path,
-                                     extra_input_params)
-    
-    ph_atoms = PhonopyAtoms(
-        symbols=stru.get_chemical_symbols(),
-        cell=stru.get_cell(),
-        scaled_positions=stru.get_scaled_positions(),
-        magnetic_moments=stru.get_initial_magnetic_moments()
-    )
+    try:
+        work_path = Path(generate_work_path()).absolute()
 
-    # Determine supercell if not provided
-    if supercell is None:
-        min_supercell_length = 6.0 # In Angstrom. A temporary value, should be verified in detail
-        a, b, c = stru.get_cell().lengths()
-        supercell = [int(np.ceil(min_supercell_length / a)),
-                     int(np.ceil(min_supercell_length / b)),
-                     int(np.ceil(min_supercell_length / c))]
+        input_params = ReadInput(os.path.join(abacus_inputs_path, "INPUT"))
+        stru_file = input_params.get('stru_file', "STRU")
+        stru = read(os.path.join(abacus_inputs_path, stru_file))
+        # Provide extra INPUT parameters necessary for calculating phonon dispersion
+        extra_input_params = {'calculation': 'scf',
+                              'cal_force': 1,
+                              'out_chg': 1,
+                              'init_chg': 'auto'}
+        if input_params.get('scf_thr', 1e-7) > 1e-7:
+            extra_input_params['scf_thr'] = 1e-7
+        calc = set_ase_abacus_calculator(abacus_inputs_path,
+                                         work_path,
+                                         extra_input_params)
 
-    phonon = Phonopy(ph_atoms, supercell_matrix=supercell)
-    phonon.generate_displacements(distance=displacement_stepsize)
-    print("Generated {} supercell structures with displacements.".format(len(phonon.supercells_with_displacements)) +
-          "Doing SCF calculations for each supercell structure...")
-    
-    force_sets = []
-    structure_index = 1
-    for sc in phonon.supercells_with_displacements:
-        sc_atoms = Atoms(
-            cell=sc.cell,
-            symbols=sc.symbols,
-            scaled_positions=sc.scaled_positions,
-            magmoms=sc.magnetic_moments,
-            pbc=True,
+        ph_atoms = PhonopyAtoms(
+            symbols=stru.get_chemical_symbols(),
+            cell=stru.get_cell(),
+            scaled_positions=stru.get_scaled_positions(),
+            magnetic_moments=stru.get_initial_magnetic_moments()
         )
-        sc_atoms.calc = calc
-        print(f"Doing SCF calculation for supercell structure {structure_index}...")
-        force = sc_atoms.get_forces()
-        force_sets.append(force - np.mean(force, axis=0))
-        structure_index += 1
 
-    phonon.forces = force_sets
-    phonon.produce_force_constants()
+        # Determine supercell if not provided
+        if supercell is None:
+            min_supercell_length = 6.0 # In Angstrom. A temporary value, should be verified in detail
+            a, b, c = stru.get_cell().lengths()
+            supercell = [int(np.ceil(min_supercell_length / a)),
+                         int(np.ceil(min_supercell_length / b)),
+                         int(np.ceil(min_supercell_length / c))]
 
-    phonon.run_mesh([20, 20, 20], with_eigenvectors=True, is_mesh_symmetry=False)
-    phonon.run_thermal_properties(temperatures=[temperature])
-    thermal = phonon.get_thermal_properties_dict()
+        phonon = Phonopy(ph_atoms, supercell_matrix=supercell)
+        phonon.generate_displacements(distance=displacement_stepsize)
+        print("Generated {} supercell structures with displacements.".format(len(phonon.supercells_with_displacements)) +
+              "Doing SCF calculations for each supercell structure...")
 
-    comm_q = get_commensurate_points(phonon.supercell_matrix)
-    freqs = np.array([phonon.get_frequencies(q) for q in comm_q])
+        force_sets = []
+        structure_index = 1
+        for sc in phonon.supercells_with_displacements:
+            sc_atoms = Atoms(
+                cell=sc.cell,
+                symbols=sc.symbols,
+                scaled_positions=sc.scaled_positions,
+                magmoms=sc.magnetic_moments,
+                pbc=True,
+            )
+            sc_atoms.calc = calc
+            print(f"Doing SCF calculation for supercell structure {structure_index}...")
+            force = sc_atoms.get_forces()
+            force_sets.append(force - np.mean(force, axis=0))
+            structure_index += 1
 
-    band_plot_path = os.path.join(work_path, "phonon_dispersion.png")
-    yaml_path = os.path.join(work_path, "phonon_dispersion.yaml")
-    phonon.auto_band_structure(
-        npoints=101,
-        write_yaml=True,
-        filename=str(yaml_path)
-    )
+        phonon.forces = force_sets
+        phonon.produce_force_constants()
 
-    band_plot = phonon.plot_band_structure()
-    band_plot.savefig(band_plot_path, dpi=300)
+        phonon.run_mesh([20, 20, 20], with_eigenvectors=True, is_mesh_symmetry=False)
+        phonon.run_thermal_properties(temperatures=[temperature])
+        thermal = phonon.get_thermal_properties_dict()
 
-    dos_dat_path = (Path(work_path) / "phonon_dos.dat").absolute()
-    phonon.auto_total_dos(write_dat = True, filename=dos_dat_path)
-    dos_plot_path = os.path.join(work_path, "phonon_dos.png")
-    dos_plot = phonon.plot_total_dos(xlabel='Frequency (THz)')
-    dos_plot.savefig(dos_plot_path, dpi=300)
+        comm_q = get_commensurate_points(phonon.supercell_matrix)
+        freqs = np.array([phonon.get_frequencies(q) for q in comm_q])
 
-    return {
-        "phonon_work_path": Path(work_path).absolute(),
-        "band_plot": Path(band_plot_path).absolute(),
-        "dos_plot": Path(dos_plot_path).absolute(),
-        'band_yaml': Path(yaml_path).absolute(),
-        'dos_dat_file': Path(dos_dat_path).absolute(),
-        "entropy": float(thermal['entropy'][0]),
-        "free_energy": float(thermal['free_energy'][0]),
-        "heat_capacity": float(thermal['heat_capacity'][0]),
-        "max_frequency_THz": float(np.max(freqs)),
-        "max_frequency_K": float(np.max(freqs) * THz_TO_K),
-    }
+        band_plot_path = os.path.join(work_path, "phonon_dispersion.png")
+        yaml_path = os.path.join(work_path, "phonon_dispersion.yaml")
+        phonon.auto_band_structure(
+            npoints=101,
+            write_yaml=True,
+            filename=str(yaml_path)
+        )
+
+        band_plot = phonon.plot_band_structure()
+        band_plot.savefig(band_plot_path, dpi=300)
+
+        dos_dat_path = (Path(work_path) / "phonon_dos.dat").absolute()
+        phonon.auto_total_dos(write_dat = True, filename=dos_dat_path)
+        dos_plot_path = os.path.join(work_path, "phonon_dos.png")
+        dos_plot = phonon.plot_total_dos(xlabel='Frequency (THz)')
+        dos_plot.savefig(dos_plot_path, dpi=300)
+
+        return {
+            "phonon_work_path": Path(work_path).absolute(),
+            "band_plot": Path(band_plot_path).absolute(),
+            "dos_plot": Path(dos_plot_path).absolute(),
+            'band_yaml': Path(yaml_path).absolute(),
+            'dos_dat_file': Path(dos_dat_path).absolute(),
+            "entropy": float(thermal['entropy'][0]),
+            "free_energy": float(thermal['free_energy'][0]),
+            "heat_capacity": float(thermal['heat_capacity'][0]),
+            "max_frequency_THz": float(np.max(freqs)),
+            "max_frequency_K": float(np.max(freqs) * THz_TO_K),
+        }
+    except Exception as e:
+        return {
+            "phonon_work_path": Path(''),
+            "band_plot": Path(''),
+            "dos_plot": Path(''),
+            'band_yaml': Path(''),
+            'dos_dat_file': Path(''),
+            "entropy": None,
+            "free_energy": None,
+            "heat_capacity": None,
+            "max_frequency_THz": None,
+            "max_frequency_K": None,
+            "message": f"Calculating phonon spectrum failed: {e}"
+        }

--- a/src/abacusagent/modules/relax.py
+++ b/src/abacusagent/modules/relax.py
@@ -90,8 +90,8 @@ def abacus_do_relax(
         }
     except Exception as e:
         return {
-            "job_path": Path(''),
-            "new_abacus_inputs_path": Path(''),
+            "job_path": None,
+            "new_abacus_inputs_path": None,
             "result": None
         }
 
@@ -137,13 +137,11 @@ def abacus_prepare_inputs_from_relax_results(
         return {
             "job_path": Path(work_path).absolute(),
             "input_content": ReadInput(os.path.join(work_path, "INPUT")),
-            "input_files": [f for f in Path(work_path).iterdir()]
         }
     except Exception as e:
         return {
-            "job_path": Path(''),
+            "job_path": None,
             "input_content": None,
-            "input_files": [Path('')],
             "message": f"Prepare new ABACUS input files from relax or cell-relax calculation output files failed: {e}"
         }
 

--- a/src/abacusagent/modules/vibration.py
+++ b/src/abacusagent/modules/vibration.py
@@ -161,7 +161,7 @@ def abacus_vibration_analysis(abacus_inputs_path: Path,
                 'vib_free_energy': float(free_energy)}
     except Exception as e:
         return {'frequencies': None,
-                'work_dir': Path(''),
+                'work_dir': None,
                 'zero_point_energy': None,
                 'vib_entropy': None,
                 'vib_free_energy': None,

--- a/src/abacusagent/modules/vibration.py
+++ b/src/abacusagent/modules/vibration.py
@@ -99,7 +99,8 @@ def abacus_vibration_analysis(abacus_inputs_path: Path,
         temperature (float): Temperature used to calculate thermodynamic quantities. Units in Kelvin.
     Returns:
         A dictionary containing the following keys:
-        - 'frequencies': List of frequencies from vibrational analysis. Imaginary frequencies will be a string ended with 'i'. Units in cm^{-1}.
+        - 'real_frequencies': List of real frequencies from vibrational analysis. Units in cm^{-1}.
+        - 'imaginary_frequencies': Imaginary frequencies will be a string ended with 'i'. Units in cm^{-1}.
         - 'work_path': Path to directory performing vibrational analysis. Containing animation of normal modes 
             with non-zero frequency in ASE traj format and `vib` directory containing collected forces.
         - 'zero_point_energy': Zero-point energy summed over all modes. Units in eV.
@@ -154,13 +155,15 @@ def abacus_vibration_analysis(abacus_inputs_path: Path,
         entropy = thermo.get_entropy(temperature)
         free_energy = thermo.get_helmholtz_energy(temperature)
 
-        return {'frequencies': freqs,
+        return {'real_frequencies': real_freq,
+                'imaginary_frequencies': imag_freq,
                 'work_dir': Path(work_path).absolute(),
                 'zero_point_energy': float(zero_point_energy),
                 'vib_entropy': float(entropy),
                 'vib_free_energy': float(free_energy)}
     except Exception as e:
-        return {'frequencies': None,
+        return {'real_frequencies': None,
+                'imaginary_frequencies': None,
                 'work_dir': None,
                 'zero_point_energy': None,
                 'vib_entropy': None,

--- a/src/abacusagent/modules/vibration.py
+++ b/src/abacusagent/modules/vibration.py
@@ -106,56 +106,64 @@ def abacus_vibration_analysis(abacus_inputs_path: Path,
         - 'vib_entropy': Vibrational entropy using harmonic approximation. Units in eV/K.
         - 'vib_free_energy': Vibrational Helmholtz free energy using harmonic approximation. Units in eV.
     """
-    work_path = Path(generate_work_path()).absolute()
+    try:
+        work_path = Path(generate_work_path()).absolute()
 
-    input_params = ReadInput(os.path.join(abacus_inputs_path, "INPUT"))
-    stru_file = input_params.get('stru_file', "STRU")
-    stru = read(os.path.join(abacus_inputs_path, stru_file))
-    # Provide extra INPUT parameters necessary for vibration analysis using finite difference
-    extra_input_params = {'calculation': 'scf',
-                          'cal_force': 1}
-    stru.calc = set_ase_abacus_calculator(abacus_inputs_path,
-                                          work_path,
-                                          extra_input_params)
+        input_params = ReadInput(os.path.join(abacus_inputs_path, "INPUT"))
+        stru_file = input_params.get('stru_file', "STRU")
+        stru = read(os.path.join(abacus_inputs_path, stru_file))
+        # Provide extra INPUT parameters necessary for vibration analysis using finite difference
+        extra_input_params = {'calculation': 'scf',
+                              'cal_force': 1}
+        stru.calc = set_ase_abacus_calculator(abacus_inputs_path,
+                                              work_path,
+                                              extra_input_params)
 
-    if selected_atoms is None:
-        selected_atoms = [i for i in range(stru.get_global_number_of_atoms())]
-    
-    vib = Vibrations(stru,
-                     name=os.path.join(work_path, "vib"),
-                     indices=selected_atoms,
-                     delta=stepsize,
-                     nfree=nfree)
-    vib.run()
-    vib.summary()
-    # Generate list of frequencies in the return value
-    frequencies = vib.get_frequencies()
-    real_freq_mask, imag_freq_mask, complex_freq_mask = identify_complex_types(frequencies)
-    real_freq, imag_freq = np.real(frequencies[real_freq_mask]).tolist(), frequencies[imag_freq_mask].tolist()
-    for key, value in enumerate(imag_freq):
-        imag_freq[key] = str(value).replace('j', 'i')
-    freqs = imag_freq + real_freq
+        if selected_atoms is None:
+            selected_atoms = [i for i in range(stru.get_global_number_of_atoms())]
 
-    # Write animations of normal modes in ASE traj format
-    vib.write_mode()
+        vib = Vibrations(stru,
+                         name=os.path.join(work_path, "vib"),
+                         indices=selected_atoms,
+                         delta=stepsize,
+                         nfree=nfree)
+        vib.run()
+        vib.summary()
+        # Generate list of frequencies in the return value
+        frequencies = vib.get_frequencies()
+        real_freq_mask, imag_freq_mask, complex_freq_mask = identify_complex_types(frequencies)
+        real_freq, imag_freq = np.real(frequencies[real_freq_mask]).tolist(), frequencies[imag_freq_mask].tolist()
+        for key, value in enumerate(imag_freq):
+            imag_freq[key] = str(value).replace('j', 'i')
+        freqs = imag_freq + real_freq
 
-    # Thermochemistry calculations
-    # Vibrations.get_energies() gets `h \nu` for each mode, which is from the eigenvalues of force constant
-    # matrix. The force constant matrix should be a real symmetric matrix mathematically, but due to numerical
-    # errors during calculating its matrix element, it will deviate from symmetric matric slightly, and its eigenvalue
-    # will have quite small imaginary parts. Magnitude of imaginary parts will decrease as the calculation accuracy
-    # increases, and it's safe to use norm of the complex eigenvalue as vibration energy if the calculation is 
-    # accurate enough.
-    vib_energies = vib.get_energies()
-    vib_energies_float = [float(np.linalg.norm(i)) for i in vib_energies]
-    zero_point_energy = sum(vib_energies_float) / 2
-    thermo = HarmonicThermo(vib_energies, ignore_imag_modes=True)
-    entropy = thermo.get_entropy(temperature)
-    free_energy = thermo.get_helmholtz_energy(temperature)
-    
-    return {'frequencies': freqs,
-            'work_dir': Path(work_path).absolute(),
-            'zero_point_energy': float(zero_point_energy),
-            'vib_entropy': float(entropy),
-            'vib_free_energy': float(free_energy)}
+        # Write animations of normal modes in ASE traj format
+        vib.write_mode()
+
+        # Thermochemistry calculations
+        # Vibrations.get_energies() gets `h \nu` for each mode, which is from the eigenvalues of force constant
+        # matrix. The force constant matrix should be a real symmetric matrix mathematically, but due to numerical
+        # errors during calculating its matrix element, it will deviate from symmetric matric slightly, and its eigenvalue
+        # will have quite small imaginary parts. Magnitude of imaginary parts will decrease as the calculation accuracy
+        # increases, and it's safe to use norm of the complex eigenvalue as vibration energy if the calculation is 
+        # accurate enough.
+        vib_energies = vib.get_energies()
+        vib_energies_float = [float(np.linalg.norm(i)) for i in vib_energies]
+        zero_point_energy = sum(vib_energies_float) / 2
+        thermo = HarmonicThermo(vib_energies, ignore_imag_modes=True)
+        entropy = thermo.get_entropy(temperature)
+        free_energy = thermo.get_helmholtz_energy(temperature)
+
+        return {'frequencies': freqs,
+                'work_dir': Path(work_path).absolute(),
+                'zero_point_energy': float(zero_point_energy),
+                'vib_entropy': float(entropy),
+                'vib_free_energy': float(free_energy)}
+    except Exception as e:
+        return {'frequencies': None,
+                'work_dir': Path(''),
+                'zero_point_energy': None,
+                'vib_entropy': None,
+                'vib_free_energy': None,
+                'message': f"Doing vibration analysis failed: {e}"}
 

--- a/src/abacusagent/modules/vibration.py
+++ b/src/abacusagent/modules/vibration.py
@@ -85,6 +85,7 @@ def abacus_vibration_analysis(abacus_inputs_path: Path,
                               temperature: Optional[float] = 298.15):
     """
     Performing vibrational analysis using finite displacement method.
+    This tool function is usually followed by a relax calculation (`calculation` is set to `relax`).
     Args:
         abacus_inputs_path (Path): Path to the ABACUS input files directory.
         selected_atoms (Optional[List[int]]): Indices of atoms included in the vibrational analysis. If this

--- a/tests/test_dos.py
+++ b/tests/test_dos.py
@@ -23,12 +23,14 @@ class TestPlotDos(unittest.TestCase):
         sys.stdout = open(os.devnull, 'w')
 
         # Call the run_dos function
-        results_test = mkplots(self.data_dir,self.data_dir, dpi=20)
+        results_test = mkplots(self.data_dir, self.data_dir, self.data_dir, dpi=20)
         results_ref = [Path(self.data_dir) / "DOS.png",
-                       Path(self.data_dir) / "Si1_pdos.png",
-                       Path(self.data_dir) / "Si2_pdos.png"]
+                       Path(self.data_dir) / "PDOS.png"]
     
         self.assertListEqual([Path(p) for p in results_test], results_ref)
+
+        if os.path.exists(self.data_dir / "metrics.json"):
+            os.remove(self.data_dir / "metrics.json")
         
         
 


### PR DESCRIPTION
Recent updates to ABACUS-agent-tools
1. Function updates
   - Support create crystal structure using lattice parameters and Wyckoff positions
   - Update plotting DOS and PDOS. Now PDOS supports 3 modes: plot PDOS for different elements (eg: Pd, C, H), for shells of different elements (eg: Pd s, p and d; C s and p) and orbital-resolved PDOS (eg: p_x, p_y and p_z for C). nspin=1 and 2 are supported.
   - Basic molecular dynamics run using ABACUS.
   - Use generated KPT file instead of possible `kspacing` in calculatin elastec properties to avoid inconsistencies between different deformed structure.
2. Code structure
   - Remove `@mcp.tool()` decorator for `run_abacus_onejob` and `generate_deeptb_config`
   - Wrap code with try ... except for each MCP tool function