### PR TITLE
Fix a bug in plotting pdos with pw basis

### DIFF
--- a/src/abacusagent/modules/abacus.py
+++ b/src/abacusagent/modules/abacus.py
@@ -30,7 +30,11 @@ def abacus_prepare(
     afm: bool = False,
     extra_input: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    """Prepare input files for ABACUS calculation.
+    """
+    Prepare mandatory input files for ABACUS calculation from a structure file.
+    This function does not perform any actual calculation, but is necessary to use this function
+    to prepare a directory containing necessary input files for ABACUS calculation. 
+    If user provides ABACUS input files by him/herself, this function should not be used.
     
     Args:
         stru_file (Path): Structure file in cif, poscar, or abacus/stru format.
@@ -40,7 +44,7 @@ def abacus_prepare(
             'relax': Geometry relaxation calculation, which will relax the atomic position to the minimum energy configuration.
             'cell-relax': Cell relaxation calculation, which will relax the cell parameters and atomic positions to the minimum energy configuration.
             'md': Molecular dynamics calculation, which will perform molecular dynamics simulation.
-        lcao (bool): Whether to use LCAO basis set, default is True. If True, the orbital library path must be provided.
+        lcao (bool): Whether to use LCAO basis set, default is True.
         nspin (int): The number of spins, can be 1 (no spin), 2 (spin polarized), or 4 (non-collinear spin). Default is 1.
         soc (bool): Whether to use spin-orbit coupling, if True, nspin should be 4.
         dftu (bool): Whether to use DFT+U, default is False.
@@ -49,7 +53,7 @@ def abacus_prepare(
             For example, {"Fe": ["d", 4], "O": ["p", 1]} means applying DFT+U to Fe 3d orbital with U=4 eV and O 2p orbital with U=1 eV.
         init_mag ( dict or None): The initial magnetic moment for magnetic elements, should be a dict like {"Fe": 4, "Ti": 1}, where the key is the element symbol and the value is the initial magnetic moment.
         afm (bool): Whether to use antiferromagnetic calculation, default is False. If True, half of the magnetic elements will be set to negative initial magnetic moment.
-        extra_input: Extra input parameters for ABACUS. 
+        extra_input: Extra input parameters in the prepared INPUT file. 
     
     Returns:
         A dictionary containing the job path.
@@ -170,8 +174,8 @@ def abacus_modify_input(
             - Value: A list with one or two elements:  
                 - One-element form: float, representing the Hubbard U value (orbital will be inferred).  
                 - Two-element form: [orbital, U], where `orbital` is one of {'p', 'd', 'f'}, and `U` is a float.
-        extra_input: Additional key-value pairs to update the INPUT file.
-        remove_input: A list of param names to be removed in the INPUT file
+        extra_input: Additional key-value pairs to update the INPUT file. If the name of the key is already in the INPUT file, the value will be updated.
+        remove_input: A list of parameter names to be removed in the INPUT file
 
     Returns:
         A dictionary containing:
@@ -414,9 +418,13 @@ def abacus_collect_data(
                           = ["normal_end", "converge", "energy", "total_time"]
 ) -> Dict[str, Any]:
     """
-    Collect results after ABACUS calculation and dump to a json file.
+    Collect results of the given metrics listed below after ABACUS calculation.
+    name of collected metrics must be selected from the list below.
+
     Args:
-        abacus_outputs_dir (str): Path to the directory containing the ABACUS job output files.
+        abacus_outputs_dir (str): Path to the directory containing the ABACUS job output files. Only work directory for
+                                  abacus_calculation_scf, abacus_do_relax and abacus_dos_run can be used. DO NOT use work
+                                  directory of any other tool functions.
         metrics (List[str]): List of metric names to collect.  
                   metric_name  description
                       version: the version of ABACUS

--- a/src/abacusagent/modules/abacus.py
+++ b/src/abacusagent/modules/abacus.py
@@ -422,9 +422,7 @@ def abacus_collect_data(
     name of collected metrics must be selected from the list below.
 
     Args:
-        abacus_outputs_dir (str): Path to the directory containing the ABACUS job output files. Only work directory for
-                                  abacus_calculation_scf, abacus_do_relax and abacus_dos_run can be used. DO NOT use work
-                                  directory of any other tool functions.
+        abacus_outputs_dir (str): Path to the directory containing the ABACUS job output files. 
         metrics (List[str]): List of metric names to collect.  
                   metric_name  description
                       version: the version of ABACUS

--- a/src/abacusagent/modules/dos.py
+++ b/src/abacusagent/modules/dos.py
@@ -78,9 +78,10 @@ def abacus_dos_run(
         
     Returns:
         Dict[str, Any]: A dictionary containing:
+            - dos_fig_path: Path to the plotted DOS.
+            - pdos_fig_path: Path to the plotted PDOS if avaliable.
             - results_scf: Results of the SCF calculation, including: work path, normal end status, SCF steps, convergence status, and energies.
             - results_nscf: Results of the NSCF calculation, including work path and normal end status.
-            - fig_paths: List of paths to the generated figures for DOS and PDOS. DOS will be saved as "DOS.png" and PDOS will be saved as "species_atom_index_pdos.png" in the output directory.
     """
     try:
         is_valid, msg = check_abacus_inputs(abacus_inputs_dir)
@@ -92,7 +93,8 @@ def abacus_dos_run(
         nspin = input_params.get("nspin", 1)
         if nspin in [4]:
             raise ValueError("Currently DOS calculation can only be plotted using for nspin=1 and nspin=2")
-
+        
+        #TODO: Check DOS calculation for pw basis set.
         metrics_scf = abacus_dos_run_scf(abacus_inputs_dir)
         metrics_nscf = abacus_dos_run_nscf(metrics_scf["scf_work_path"],
                                            dos_edelta_ev=dos_edelta_ev,

--- a/src/abacusagent/modules/dos.py
+++ b/src/abacusagent/modules/dos.py
@@ -59,8 +59,8 @@ def abacus_dos_run(
     
     This function will firstly run a SCF calculation with out_chg set to 1, 
     then run a NSCF calculation with init_chg set to 'file' and out_dos set to 1 or 2.
-    If the INPUT parameter "basis" is "PW", then out_dos will be set to 1, and only DOS will be calculated.
-    If the INPUT parameter "basis" is "LCAO", then out_dos will be set to 2, and both DOS and PDOS will be calculated.
+    If the INPUT parameter "basis_type" is "PW", then out_dos will be set to 1, and only DOS will be calculated and plotted.
+    If the INPUT parameter "basis_type" is "LCAO", then out_dos will be set to 2, and both DOS and PDOS will be calculated and plotted.
     
     Args:
         abacus_inputs_dir: Path to the ABACUS input files, which contains the INPUT, STRU, KPT, and pseudopotential or orbital files.
@@ -79,7 +79,7 @@ def abacus_dos_run(
     Returns:
         Dict[str, Any]: A dictionary containing:
             - dos_fig_path: Path to the plotted DOS.
-            - pdos_fig_path: Path to the plotted PDOS if avaliable.
+            - pdos_fig_path: Path to the plotted PDOS. Only for LCAO basis.
             - results_scf: Results of the SCF calculation, including: work path, normal end status, SCF steps, convergence status, and energies.
             - results_nscf: Results of the NSCF calculation, including work path and normal end status.
     """
@@ -94,7 +94,6 @@ def abacus_dos_run(
         if nspin in [4]:
             raise ValueError("Currently DOS calculation can only be plotted using for nspin=1 and nspin=2")
         
-        #TODO: Check DOS calculation for pw basis set.
         metrics_scf = abacus_dos_run_scf(abacus_inputs_dir)
         metrics_nscf = abacus_dos_run_nscf(metrics_scf["scf_work_path"],
                                            dos_edelta_ev=dos_edelta_ev,
@@ -570,11 +569,11 @@ def plot_dos_pdos(scf_job_path: Path,
         else:
             print(f"Warning: PDOS calculation not supported for PW basis type, skipping PDOS plotting")
     elif os.path.exists(pdos_file) and not os.path.exists(basref_file):
-        print(f"Warning: PDOS file exists but basref file not found - {basref_file}, skipping PDOS plotting")
+        print(f"Warning: PDOS file exists but Orbital file not found - {basref_file}, skipping PDOS plotting")
     elif not os.path.exists(pdos_file) and os.path.exists(basref_file):
-        print(f"Warning: Basref file exists but PDOS file not found - {pdos_file}, skipping PDOS plotting")
+        print(f"Warning: Orbital file exists but PDOS file not found - {pdos_file}, skipping PDOS plotting")
     else:
-        print("Warning: Both PDOS and basref files not found, skipping PDOS plotting")
+        print("Warning: Both PDOS and Orbital files not found, skipping PDOS plotting")
 
     print("Plots generated:")
     for file in all_plot_files:

--- a/src/abacusagent/modules/eos.py
+++ b/src/abacusagent/modules/eos.py
@@ -42,7 +42,7 @@ def abacus_eos(
     scale_stepsize: float = 0.02
 ):
     """
-    Use Birch-Murnaghan equation of state (EOS) to calculate the EOS data.
+    Use Birch-Murnaghan equation of state (EOS) to calculate the EOS data. The shape of fitted crystal is limited to cubic now.
 
     Args:
         abacus_inputs_dir (Path): Path to the ABACUS input files, which contains the INPUT, STRU, KPT, and pseudopotential or orbital files.

--- a/src/abacusagent/modules/phonon.py
+++ b/src/abacusagent/modules/phonon.py
@@ -26,7 +26,7 @@ def abacus_phonon_dispersion(
     temperature: Optional[float] = 298.15,
 ):
     """
-    Calculate phonon dispersion using Phonopy with ABACUS as the calculator. 
+    Calculate phonon dispersion with finite-difference method using Phonopy with ABACUS as the calculator. 
     This tool function is usually followed by a cell-relax calculation (`calculation` is set to `cell-relax`). 
     Args:
         abacus_inputs_dir (Path): Path to the directory containing ABACUS input files.

--- a/tests/integrate_test/abacus_inputs_dirs/Fe-BCC-prim/INPUT_pw_nspin2_gammaonly
+++ b/tests/integrate_test/abacus_inputs_dirs/Fe-BCC-prim/INPUT_pw_nspin2_gammaonly
@@ -1,0 +1,13 @@
+INPUT_PARAMETERS
+calculation 	scf
+ecutwfc 	100
+scf_thr 	1e-05
+scf_nmax 	100
+smearing_method 	gauss
+smearing_sigma 	0.015
+mixing_type 	broyden
+mixing_beta 	0.2
+basis_type 	pw
+ks_solver 	dav_subspace
+gamma_only      1
+nspin 	2

--- a/tests/integrate_test/abacus_inputs_dirs/NaCl-prim/INPUT_pw_nspin1
+++ b/tests/integrate_test/abacus_inputs_dirs/NaCl-prim/INPUT_pw_nspin1
@@ -1,0 +1,16 @@
+INPUT_PARAMETERS
+calculation 	scf
+symmetry 	1
+ecutwfc 	100
+scf_thr 	1e-05
+scf_nmax 	100
+smearing_method 	gauss
+smearing_sigma 	0.001
+mixing_type 	broyden
+mixing_beta 	0.7
+basis_type 	pw
+ks_solver 	dav_subspace
+#cal_force 	1
+#cal_stress 	1
+#kspacing 	0.14 # unit in 1/bohr
+gamma_only 	1

--- a/tests/integrate_test/data/ref_results.json
+++ b/tests/integrate_test/data/ref_results.json
@@ -98,6 +98,18 @@
             "scf_energy": -3220.427369911483
         }
     },
+    "test_abacus_dos_run_pw_nspin1":
+    {
+        "result": {
+            "scf_energy": -1688.713546837392
+        }
+    },
+    "test_abacus_dos_run_pw_nspin2":
+    {
+        "result": {
+            "scf_energy": -3228.693783965023
+        }
+    },
     "test_abacus_cal_elastic_si_prim":
     {
         "result": {

--- a/tests/integrate_test/test_dos.py
+++ b/tests/integrate_test/test_dos.py
@@ -17,8 +17,10 @@ class TestAbacusDosRun(unittest.TestCase):
         self.abacus_inputs_dir_nacl_prim = Path(__file__).parent / 'abacus_inputs_dirs/NaCl-prim/'
         self.stru_dos_nacl_prim = self.abacus_inputs_dir_nacl_prim / "STRU_dos"
         self.input_dos_nacl_prim = self.abacus_inputs_dir_nacl_prim / "INPUT_nspin1"
+        self.input_dos_pw_nacl_prim = self.abacus_inputs_dir_nacl_prim / "INPUT_pw_nspin1"
         self.abacus_inputs_dir_fe_bcc_prim = Path(__file__).parent / 'abacus_inputs_dirs/Fe-BCC-prim/'
         self.stru_dos_fe_bcc_prim = self.abacus_inputs_dir_fe_bcc_prim / "STRU_dos"
+        self.input_dos_pw_fe_bcc_prim = self.abacus_inputs_dir_fe_bcc_prim / "INPUT_pw_nspin2_gammaonly"
 
         self.original_cwd = os.getcwd()
         os.chdir(self.test_path)
@@ -178,6 +180,51 @@ class TestAbacusDosRun(unittest.TestCase):
 
         self.assertIsInstance(dos_fig_path, get_path_type())
         self.assertIsInstance(pdos_fig_path, get_path_type())
+        self.assertTrue(outputs['scf_normal_end'])
+        self.assertTrue(outputs['scf_converge'])
+        self.assertTrue(outputs['nscf_normal_end'])
+        self.assertAlmostEqual(outputs['scf_energy'], ref_results['scf_energy'])
+    
+    def test_abacus_dos_run_pw_nspin1(self):
+        """
+        Test the abacus_dos_run function with nspin=1 case with pw basis
+        """
+        test_func_name = inspect.currentframe().f_code.co_name
+        ref_results = load_test_ref_result(test_func_name)
+
+        test_work_dir = self.test_path / test_func_name
+        shutil.copytree(self.abacus_inputs_dir_nacl_prim, test_work_dir)
+        shutil.copy2(self.stru_dos_nacl_prim, test_work_dir / "STRU")
+        shutil.copy2(self.input_dos_pw_nacl_prim, test_work_dir / "INPUT")
+
+        outputs = abacus_dos_run(test_work_dir)
+
+        dos_fig_path = outputs['dos_fig_path']
+
+        self.assertIsInstance(dos_fig_path, get_path_type())
+        self.assertTrue(outputs['scf_normal_end'])
+        self.assertTrue(outputs['scf_converge'])
+        self.assertTrue(outputs['nscf_normal_end'])
+        self.assertAlmostEqual(outputs['scf_energy'], ref_results['scf_energy'])
+
+    def test_abacus_dos_run_pw_nspin2(self):
+        """
+        Test the abacus_dos_run function with nspin=2 case with pw basis
+        """
+        test_func_name = inspect.currentframe().f_code.co_name
+        ref_results = load_test_ref_result(test_func_name)
+
+        test_work_dir = self.test_path / test_func_name
+        shutil.copytree(self.abacus_inputs_dir_fe_bcc_prim, test_work_dir)
+        shutil.copy2(self.stru_dos_fe_bcc_prim, test_work_dir / "STRU")
+        shutil.copy2(self.input_dos_pw_fe_bcc_prim, test_work_dir / "INPUT")
+
+        outputs = abacus_dos_run(test_work_dir)
+        print(outputs)
+
+        dos_fig_path = outputs['dos_fig_path']
+
+        self.assertIsInstance(dos_fig_path, get_path_type())
         self.assertTrue(outputs['scf_normal_end'])
         self.assertTrue(outputs['scf_converge'])
         self.assertTrue(outputs['nscf_normal_end'])


### PR DESCRIPTION
Fix bugs in plotting PDOS with pw basis. Now the returned dictionary of abacus_dos_run will not contain 'pdos_fig_path' if `basis_type` is `pw`.
Besides, outdated docstring of tool functions were modified.