### PR TITLE
Use empty atom for defect supercell structure to account for BSSE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,17 @@ dynamic = ["version"]
 description = "Abacus agent"
 requires-python = ">=3.11"
 
+dependencies = [
+       "abacustest>=0.4.38",
+       "numpy<2.0",
+       "pymatgen>=2025.5.28",
+       "bohr-agent-sdk==0.1.100",
+       "bohrium-sdk==0.13.0",
+       "dpdata>=0.2.24",
+       "regex==2024.11.6",
+       "pyatb==1.1.1"
+]
+
 [project.scripts]
 abacusagent = "abacusagent.main:main"
 

--- a/quick_start/agent.py
+++ b/quick_start/agent.py
@@ -1,0 +1,113 @@
+from google.adk.agents import Agent
+from google.adk.models.lite_llm import LiteLlm
+from dp.agent.adapter.adk import CalculationMCPToolset
+from google.adk.tools.mcp_tool.mcp_session_manager import SseServerParams, StreamableHTTPServerParams
+
+import os, json
+
+# Set the secret key in ~/.abacusagent/env.json or as an environment variable, or modify the code to set it directly.
+env_file = os.path.expanduser("~/.abacusagent/env.json")
+if os.path.isfile(env_file):
+    env = json.load(open(env_file, "r"))
+else:
+    env = {}
+abacusagent_host = env.get("ABACUSAGENT_HOST", os.environ.get("ABACUSAGENT_HOST", ""))
+abacusagent_port = env.get("ABACUSAGENT_PORT", os.environ.get("ABACUSAGENT_PORT", 50001))
+model_name = env.get("LLM_MODEL", os.environ.get("LLM_MODEL", ""))
+model_api_key = env.get("LLM_API_KEY", os.environ.get("LLM_API_KEY", ""))
+model_base_url = env.get("LLM_BASE_URL", os.environ.get("LLM_BASE_URL", ""))
+
+instruction = """
+You are an expert in computational materials science and computational chemistry.
+Help users perform ABACUS including single point calculation, structure optimization, molecular dynamics and property calculations.
+After your submitted calculation is finished, show all the results directly.
+Use default parameters if the users do not mention, but let users confirm them before submission.
+If phonon calculation is requested, a cell-relax calculation must be done ahead. If a vibrational analysis calculation
+ is requested, a relax calculation must be done ahead. If other property calculation (band, Bader charge, elastic modulus, DOS etc.)
+ is requested, relax calculation (for molecules and adsorb systems) or cell-relax calculation (for bulk crystals or 2D materials) are
+ not a must but strongly encouraged.
+Always verify the input parameters to users and provide clear explanations of results.
+Do not try to modify the input files without explicit permission when errors occured.
+The LCAO basis is prefered.
+If path to output files are provided, **always** tell the users the path to output files in the response.
+
+A typical workflow is:
+1. Using abacus_prepare to generate ABACUS input file directory using structure file as argument of abacus_prepare. This step is **MANDATORY**.
+2. (Optional) using abacus_modify_input and abacus_modify_stru to modify INPUT and STRU file in given ABACUS input file directory,
+3. Using abacus_do_relax to do a cell-relax calculation for given material,
+4. Do property calculations like phonon dispersion, band, etc.
+
+Since we use asynchronous job submission in this agent, **ONLY 1 TOOL FUNCTION** should be used for 1 step. **DO NOT USE abacus_collect_data
+AND abacus_prepare_inputs_from_relax_results UNLESS EXPLITY REQUESTED**.
+
+Since ABACUS calculation uses not only structure file, but also INPUT file contains parameters controlling its calculation and pseudopotential and orbital
+files used in DFT calculation, a necessary step is to prepare an ABACUS inputs directory containing structure file, INPUT, pesudopotential and orbital files.
+If user wants to obtain property from ABACUS calculation, abacus_prepare **MUST** be used before calling any tool function to calculate the property, and use
+structure file as argument of tool functions is **STRICTLY FORBIDDEN**.
+
+Here we briefly introduce functions of avaliable tool functions and suggested use method below:
+
+ABACUS input files generation:
+Used to generate ABACUS input files from a given structure file.
+- abacus_prepare: Prepare ABACUS input file directory from structure file and provided information.
+    Must be used when only structure file is avaliable (in cif, poscar or abacus/stru format) and obtaining property from ABACUS calculation is requested.
+- abacus_modify_input: Modify ABACUS INPUT file in prepared ABACUS input file directory.
+    Should only be used when abacus_prepare is finished.
+- abacus_modify_stru: Modify ABACUS STRU file in prepared ABACUS input file directory.
+    Should only be used when abacus_prepare is finished.
+
+Property calculations:
+The following tool functions **MUST** use ABACUS inputs directory from abacus_prepare as an argument, and using a structure file is **STRICTLY FORBIDDEN**.
+- abacus_calculation_scf: Do a SCF calculation using the given ABACUS inputs directory.
+- abacus_do_relax: Do relax (only relax the position of atoms in a cell) or cell-relax (relax the position of atoms and lattice parameters simutaneously)
+    for a given structure. abacus_phonon_dispersiton should only be used after using this function to do a cell-relax calculation,
+    and abacus_vibrational_analysis should only be used after using this function to do a cell-relax calculation.
+    This function will give a new ABACUS input file directory containing the relaxed structure in STRU file, and keep input parameters in
+    original ABACUS input directory. Calculating properties should use the new directory.
+    It is not necessary but strongly suggested using this tool function before calculating other properties like band,
+    Bader charge, DOS/PDOS and elastic properties
+- abacus_badercharge_run: Calculate the Bader charge of given structure.
+- abacus_cal_band: Calculate the electronic band of given structure. Support two modes: `nscf` mode, do a nscf calculation
+    after a scf calculation as normally done; `pyatb` mode, use PYATB to plot the band after a scf run. The default is PYATB.
+    Currently 2D material is not supported.
+- abacus_cal_elf: Calculate the electroic localization function of given system and return a cube file containing ELF.
+- abacus_cal_charge_density_difference: Calculate the charge density difference of a given system divided into to subsystems.
+    Atom indices should be explicitly requested if not certain.
+- abacus_cal_spin_density: Calculate the spin density of given  structure. A cube file containing the spin density will be returned.
+- abacus_dos_run: Calculate the DOS and PDOS of the given structure. Support non-magnetic and collinear spin-polarized now.
+    Support 3 modes to plot PDOS: 1. Plot PDOS for each element; 2. Plot PDOS for each shell of each element (d orbital for Pd for example),
+    3. Plot PDOS for each orbital of each element (p_x, p_y and p_z for O for example). Path to plotted DOS and PDOS will be returned.
+- abacus_cal_elastic: Calculate elastic tensor (in Voigt notation) and related bulk modulus, shear modulus and young's modulus and
+    Poisson ratio from elastic tensor.
+- abacus_eos: Fit Birch-Murnaghan equation of state for cubic crystal. This function should only be used for cubic crystal.
+- abacus_phonon_dispersion: Calculate phonon dispersion curve for bulk material. Currently 2D material is not supported.
+    Should only be used after using abacus_do_relax to do a cell-relax calculation is finished.
+- abacus_vibrational_analysis: Do vibrational analysis using finite-difference method. Should only be used after using abacus_do_relax
+    to do a relax calculation is finished. Indices of atoms considerer should be explicitly requested if not certain.
+- abacus_run_md: Run ab-inito molecule dynamics calculation using ABACUS.
+
+Result collection:
+Most tool function will return the calculated property directly, and **NO ANY MORE** steps are needed. The tool function abacus_collect_data
+**SHOULD ONLY BE USED** after calling tool function abacus_calculation_scf and abacus_do_relax finished.
+"""
+
+toolset = CalculationMCPToolset(
+    connection_params=SseServerParams(
+        url=f"http://{abacusagent_host}:{abacusagent_port}/sse", # Or any other MCP server URL
+        sse_read_timeout=3000,  # Set SSE timeout to 3000 seconds
+    ),
+)
+
+root_agent = Agent(
+    name='agent',
+    model=LiteLlm(
+        model=model_name,
+        base_url=model_base_url,
+        api_key=model_api_key
+    ),
+    description=(
+        "Do ABACUS calculations."
+    ),
+    instruction=instruction,
+    tools=[toolset]
+)

--- a/quick_start/prepare_abacusagent_env.py
+++ b/quick_start/prepare_abacusagent_env.py
@@ -1,0 +1,113 @@
+import json
+from pathlib import Path
+
+config = {}
+
+print("""
+接下来我将为你配置启动abacusagent所需的设置，请根据提示提供所需的信息。
+""")
+
+print("你想将运行abacusagent时产生的文件放在哪个目录？默认为/tmp/abacusagent，按Enter键使用默认值，或输入你想要的路径：")
+response = input()
+if response.strip() == "":
+    output_dir = "/tmp/abacusagent"
+else:
+    output_dir = response.strip()
+config['ABACUSAGENT_WORK_PATH'] = output_dir
+
+config['ABACUSAGENT_SUBMIT_TYPE'] = 'local'
+
+print("请设置运行abacusagent的Host地址，默认为127.0.0.1，按Enter键使用默认值，或输入你希望使用的Host地址：")
+response = input()
+if response.strip() == "":
+    host = "127.0.0.1"
+else:
+    host = response.strip()
+config['ABACUSAGENT_HOST'] = host
+
+print("请设置运行abacusagent的端口号，默认为50001，按Enter键使用默认值，或输入你希望使用的端口号：")
+response = input()
+if response.strip() == "":
+    port = 50001
+else:
+    port = int(response.strip())
+config['ABACUSAGENT_PORT'] = port
+
+print("请设置运行ABACUS的命令，默认为'OMP_NUM_THREADS=1 mpirun -np 4 abacus |tee log'，按Enter键使用默认值，或输入你希望使用的运行ABACUS的命令：")
+response = input()
+if response.strip() == "":
+    command = "OMP_NUM_THREADS=1 mpirun -np 4 abacus |tee log"
+else:
+    command = response.strip()
+config['ABACUS_COMMAND'] = command
+
+pp_path, orb_path = Path("./apns-pseudopotentials-v1"), Path("./apns-orbitals-efficiency-v1")
+if Path("./apns-pseudopotentials-v1").exists():
+    print(f"ABACUS计算使用的APNS-PP-ORB-V1赝势已被下载到{pp_path.absolute()}，按Enter键使用，或输入你希望使用的赝势的目录：")
+    response = input()  
+    if response.strip() == "":
+        pp_path = ""
+    else:
+        pp_path = response.strip()
+else:
+    print(f"未找到默认的APNS-PP-ORB-V1赝势，请输入你希望使用的赝势的目录：")
+    response = input()
+    if response.strip() == "":
+        print("未设置赝势所在目录！")
+        pp_path = ""
+    else:
+        pp_path = response.strip()
+config['ABACUS_PP_PATH'] = pp_path
+
+if Path("./apns-orbitals-efficiency-v1").exists():   
+    print(f"ABACUS计算使用的APNS-PP-ORB-V1数值原子轨道基组已被下载到{orb_path.absolute()}，按Enter键使用，或输入你希望使用的赝势的目录：")
+    response = input()
+    if response.strip() == "":
+        orb_path = ""
+    else:
+        orb_path = response.strip()
+else:
+    print(f"未找到默认的APNS-PP-ORB-V1数值原子轨道基组，请输入你希望使用的数值原子轨道基组的目录：")
+    response = input()
+    if response.strip() == "":
+        print("未设置数值原子轨道基组所在目录！")
+        orb_path = ""
+    else:
+        orb_path = response.strip()
+    config['ABACUS_ORB_PATH'] = orb_path
+
+print("请设置LLM模型名称，目前支持直接设置通义千问(openai/qwen-turbo)、豆包(openai/doubao-seed-1-6-250625)和DeepSeek(deepseek/deepseek-chat)，请输入你希望使用的模型名称，默认值为空，需要你自己修改智能体文件，设置LLM模型：")
+
+while True:
+    response = input()
+    model_name = response.strip()
+    
+    if model_name == "":
+        config['LLM_MODEL'] = ""
+        break
+    elif model_name in ['openai/qwen-turbo', 'openai/doubao-seed-1-6-250625', 'deepseek/deepseek-chat']:
+        config['LLM_MODEL'] = model_name
+        break
+    else:
+        print("未识别的模型名称，请重新输入")
+
+if model_name in ['openai/qwen-turbo', 'openai/qwen-plus', 'openai/qwen-max']:
+    config['LLM_BASE_URL'] = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+elif model_name in ['openai/doubao-seed-1-6-250625']:
+    config['LLM_BASE_URL'] = "https://ark.cn-beijing.volces.com/api/v3"
+else:
+    config['LLM_BASE_URL'] = ""
+
+print("请设置LLM模型的API Key，默认值为空，需要你自己修改智能体文件，设置API Key：")
+response = input()
+if response.strip() == "":
+    model_api_key = ""
+else:
+    model_api_key = response.strip()
+config['LLM_API_KEY'] = model_api_key
+
+abacusagent_envfile_dir = Path.home() / ".abacusagent"
+abacusagent_envfile_dir.mkdir(exist_ok=True)
+abacusagent_envfile = abacusagent_envfile_dir / "env.json"
+with open(abacusagent_envfile, "w") as f:
+    json.dump(config, f, indent=4)

--- a/quick_start/quick_start.sh
+++ b/quick_start/quick_start.sh
@@ -19,9 +19,15 @@ conda activate $CONDA_ENV_NAME
 # 安装ABACUS-agent-tools
 cd ../
 pip install . # 依赖安装还需要补充检查
+git clone https://gitlab.com/1041176461/ase-abacus.git #ase-abacus
+cd ase-abacus
+pip install . 
+cd ..
+
 pip install google-adk
 pip install bohr-agent-sdk
 pip install litellm
+
 cd quick_start
 
 # 下载APNS-PP-ORB-v1赝势和轨道

--- a/quick_start/quick_start.sh
+++ b/quick_start/quick_start.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# 下载ABACUS-agent-tools
+#git clone https://github.com/deepmodelling/ABACUS-agent-tools.git
+#cd ABACUS-agent-tools/quick_start
+
+# 提示用户输入conda环境名称，并提供默认值
+echo -n "请输入conda环境名称（直接回车使用默认值 abacus_agent）: "
+read CONDA_ENV_NAME
+
+# 设置默认值
+CONDA_ENV_NAME=${CONDA_ENV_NAME:-my_abacus_agent}
+
+# 创建并激活环境
+conda create -n $CONDA_ENV_NAME python=3.11
+source $(conda info --base)/etc/profile.d/conda.sh
+conda activate $CONDA_ENV_NAME
+
+# 安装ABACUS-agent-tools
+cd ../
+pip install . # 依赖安装还需要补充检查
+pip install google-adk
+pip install bohr-agent-sdk
+pip install litellm
+cd quick_start
+
+# 下载APNS-PP-ORB-v1赝势和轨道
+if [ ! -f "ABACUS-APNS-PPORBs-v1.zip" ]; then
+    echo "Downloading dataset..."
+    wget https://store.aissquare.com/datasets/af21b5d9-19e6-462f-ada1-532f47f165f2/ABACUS-APNS-PPORBs-v1.zip
+else
+    echo "Pseudopotential and orbital file already downloaded."
+fi
+if [ ! -d "apns-orbitals-efficiency-v1" ] || [ ! -d "apns-pseudopotentials-v1" ]; then
+    echo "Unzipping dataset..."
+    unzip -u ABACUS-APNS-PPORBs-v1.zip
+else
+    echo "Directory containing pseudopotential and orbital files already exists."
+fi
+
+ref_agent_file=$(realpath "./agent.py")
+# 设置abacusagent的参数
+python3 prepare_abacusagent_env.py
+abacusagent --model dp --host 0.0.0.0 --port 50001 > abacusagent.log 2>&1 &
+
+# 创建智能体所需的文件，并启动
+if [ ! -d "agent" ]; then
+    mkdir agent
+fi
+pwd
+cd agent
+abacusagent --create
+cp $ref_agent_file abacus-agent/agent.py
+adk web --port 50002 --host 0.0.0.0

--- a/src/abacusagent/modules/submodules/vacancy.py
+++ b/src/abacusagent/modules/submodules/vacancy.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 from typing import List, Dict, Any, Literal
+import copy
 from itertools import groupby
 
 from ase.build import bulk
@@ -11,8 +12,6 @@ from abacustest.lib_model.comm import check_abacus_inputs
 from abacusagent.modules.util.comm import generate_work_path, link_abacusjob, run_abacus
 from abacusagent.modules.submodules.structure_generator import ELEMENT_CRYSTAL_STRUCTURES
 from abacusagent.modules.submodules.relax import relax_postprocess
-
-MAGNETIC_CRYSTALS = {"Fe", "Ni", "Co", "Cr", "Mn"}
 
 def build_most_stable_elementary_crys_stru(element: str, pp: str, orb: str) -> AbacusStru:
     """
@@ -69,7 +68,7 @@ def abacus_cal_vacancy_formation_energy(
         supercell_matrix (List[int]): Supercell matrix. Defaults to [1, 1, 1], which means no supercell.
         vacancy_element (str): Element to be removed. Default is None, which means the first type of element in the structure.
         vacancy_element_index (int): Index of the vacancy element. The index starts from 1 and is in the original structure. Defaults to 1.
-        relax_precision (Literal['low', 'medium', 'high']): The precision of the relax calculation, can be 'low', 'medium', or 'high'. Default is 'medium'.
+        relax_precision (Literal['low', 'medium', 'high']): The precision of the relax calculation, can be 'low', 'medium', or 'high'. Default is 'low'.
             'Low' means the relax calculation will be done with force_thr_ev=0.05 and stress_thr_kbar=5.
             'Medium' means the relax calculation will be done with force_thr_ev=0.01 and stress_thr_kbar=1.0.
             'High' means the relax calculation will be done with force_thr_ev=0.005 and stress_thr_kbar=0.5.
@@ -93,7 +92,8 @@ def abacus_cal_vacancy_formation_energy(
 
         supercell_stru = original_stru.supercell(supercell)
         vacancy_element_index -= 1
-        defect_supercell_stru = supercell_stru.delete_atom(vacancy_element, vacancy_element_index)
+        defect_supercell_stru = copy.deepcopy(supercell_stru)
+        defect_supercell_stru.set_empty_atom(vacancy_element, vacancy_element_index)
 
         input_params['calculation'] = 'cell-relax'
         input_params['relax_method'] = 'cg'

--- a/tests/integrate_test/pytest.ini
+++ b/tests/integrate_test/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    long: marks tests as long time usage (deselect with '-m "not long"')
+

--- a/tests/integrate_test/test_tool_wrapper.py
+++ b/tests/integrate_test/test_tool_wrapper.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import unittest
 import tempfile
 import inspect
+import pytest
 from abacusagent.modules.tool_wrapper import run_abacus_calculation
 from utils import initilize_test_env, load_test_ref_result, get_path_type
 
@@ -182,6 +183,7 @@ class TestToolWrapper(unittest.TestCase):
         self.assertIsInstance(band_picture, get_path_type())
         self.assertAlmostEqual(outputs['band_gap'], ref_results['band_gap'], places=4)
     
+    @pytest.mark.long
     def test_run_abacus_calculation_elastic_properties(self):
         """
         Test the abacus_calculation_scf function to calculate elastic properties
@@ -208,6 +210,7 @@ class TestToolWrapper(unittest.TestCase):
         self.assertAlmostEqual(outputs['young_modulus'], ref_results['young_modulus'], places=2)
         self.assertAlmostEqual(outputs['poisson_ratio'], ref_results['poisson_ratio'], places=2)
     
+    @pytest.mark.long
     def test_run_abacus_calculation_phonon_dispersion(self):
         """
         Test the abacus_calculation_scf function to calculate phonon dispersion


### PR DESCRIPTION
The generated supercell structure with vacancy now is defined by an empty atom to consider BSSE for LCAO calculation.