### PR TITLE
Fix bug in vibration.py

### DIFF
--- a/tests/integrate_test/data/ref_results.json
+++ b/tests/integrate_test/data/ref_results.json
@@ -194,6 +194,15 @@
             "vib_free_energy": 0.1834753687243439
         }
     },
+    "test_abacus_vibration_analysis_h2_selected":
+    {
+        "result": {
+            "frequencies": [58.98644787490194, 58.98644787490194, 3035.9634063376648],
+            "zero_point_energy": 0.19551913052685363,
+            "vib_entropy": 0.0004398879187182639,
+            "vib_free_energy": 0.08145444835006974
+        }
+    },
     "test_abacus_run_md_nve":
     {
         "result": {}

--- a/tests/integrate_test/test_vibration.py
+++ b/tests/integrate_test/test_vibration.py
@@ -49,3 +49,31 @@ class TestAbacusVibrationAnalysis(unittest.TestCase):
         self.assertAlmostEqual(outputs['zero_point_energy'], ref_results['zero_point_energy'], places=4)
         self.assertAlmostEqual(outputs['vib_entropy'], ref_results['vib_entropy'], places=4)
         self.assertAlmostEqual(outputs['vib_free_energy'], ref_results['vib_free_energy'], places=4)
+
+    def test_abacus_vibration_analysis_h2_selected(self):
+        """
+        Test the abacus_vibration_analysis function for relaxed H2 molecule.
+        Only 1 atom are selected for vibration analysis.
+        """
+        test_func_name = inspect.currentframe().f_code.co_name
+        ref_results = load_test_ref_result(test_func_name)
+
+        test_work_dir = self.test_path / test_func_name
+        shutil.copytree(self.abacus_inputs_dir_h2, test_work_dir)
+        shutil.copy2(self.stru_h2_relaxed, test_work_dir / "STRU")
+
+        outputs = abacus_vibration_analysis(test_work_dir,
+                                            selected_atoms = [1],
+                                            stepsize = 0.01,
+                                            nfree = 2,
+                                            temperature=400)
+        print(outputs)
+        
+        self.assertIsInstance(outputs['vib_analysis_work_dir'], get_path_type())
+
+        for freq_output, freq_ref in zip(outputs['frequencies'], ref_results['frequencies']):
+            self.assertAlmostEqual(freq_output, freq_ref, places=2)
+
+        self.assertAlmostEqual(outputs['zero_point_energy'], ref_results['zero_point_energy'], places=4)
+        self.assertAlmostEqual(outputs['vib_entropy'], ref_results['vib_entropy'], places=4)
+        self.assertAlmostEqual(outputs['vib_free_energy'], ref_results['vib_free_energy'], places=4)


### PR DESCRIPTION
The bug when not all atoms are selected is fixed. 
In previous code, the dumped `cache.xxx.json` containing forces doesn't contain forces which is not selected, and will raise error in if not selected. 
The prepare process of input files for ABACUS calculation on displaced structures are reconstructed to be an independent function now.