### PR TITLE
Update bader tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ testpaths = ["tests"]
 addopts = "-v"        
 
 [project.optional-dependencies]
-dev = ["mcp>=1.9.0",
-       "abacustest>=0.4.37",
+dev = ["mcp>=1.10.0",
+       "abacustest>=0.4.49",
        "science-agent-sdk"
 ]

--- a/src/abacusagent/modules/bader.py
+++ b/src/abacusagent/modules/bader.py
@@ -19,10 +19,13 @@ def abacus_badercharge_run(
     
     Returns:
     dict: A dictionary containing: 
-        - bader_charges: List of Bader charge for each atom.
+        - net_bader_charges: List of net Bader charge for each atom. Core charge is included.
+        - number_of_electrons: List of number of electrons around each atom. Core charge is not included.
+        - core_charges: List of core charge for each atom.
         - atom_labels: Labels of atoms in the structure.
         - abacus_workpath: Absolute path to the ABACUS work directory.
         - badercharge_run_workpath: Absolute path to the Bader analysis work directory.
+        - bader_result_csv: Absolute path to the CSV file containing detailed Bader charge results
     """
     return _abacus_badercharge_run(abacus_inputs_dir)
 
@@ -40,7 +43,7 @@ def calculate_bader_charge_from_cube(
     
     Returns:
     dict: A dictionary containing:
-        - net_charges: List of net charge for each atom. Core charge is included.
+        - net_bader_charges: List of net charge for each atom. Core charge is included.
         - number_of_electrons: List of number of electrons around each atom. Core charge is not included.
         - core_charges: List of core charge for each atom.
         - work_path: Absolute path to the work directory.

--- a/tests/integrate_test/data/ref_results.json
+++ b/tests/integrate_test/data/ref_results.json
@@ -27,14 +27,14 @@
     "test_abacus_badercharge_run_nspin1": 
     {
         "result": {
-            "net_charges": [0.930, -0.930],
+            "net_bader_charges": [0.930, -0.930],
             "atom_labels": ["Na", "Cl"]
         }
     },
     "test_abacus_badercharge_run_nspin2": 
     {
         "result": {
-            "net_charges": [0.930, -0.930],
+            "net_bader_charges": [0.930, -0.930],
             "atom_labels": ["Na", "Cl"]
         }
     },

--- a/tests/integrate_test/test_bader.py
+++ b/tests/integrate_test/test_bader.py
@@ -43,7 +43,7 @@ class TestAbacusBaderchargeRun(unittest.TestCase):
         badercharge_run_workpath = outputs['badercharge_run_workpath']
         self.assertIsInstance(abacus_workpath, get_path_type())
         self.assertIsInstance(badercharge_run_workpath, get_path_type())
-        for act, ref in zip(outputs['net_charges'], ref_results['net_charges']):
+        for act, ref in zip(outputs['net_bader_charges'], ref_results['net_bader_charges']):
             self.assertAlmostEqual(act, ref, places=3)
         for act, ref in zip(outputs['atom_labels'], ref_results['atom_labels']):
             self.assertEqual(act, ref)
@@ -68,7 +68,7 @@ class TestAbacusBaderchargeRun(unittest.TestCase):
         badercharge_run_workpath = outputs['badercharge_run_workpath']
         self.assertIsInstance(abacus_workpath, get_path_type())
         self.assertIsInstance(badercharge_run_workpath, get_path_type())
-        for act, ref in zip(outputs['net_charges'], ref_results['net_charges']):
+        for act, ref in zip(outputs['net_bader_charges'], ref_results['net_bader_charges']):
             self.assertAlmostEqual(act, ref, places=3)
         for act, ref in zip(outputs['atom_labels'], ref_results['atom_labels']):
             self.assertEqual(act, ref)

--- a/tests/integrate_test/test_tool_wrapper.py
+++ b/tests/integrate_test/test_tool_wrapper.py
@@ -220,10 +220,11 @@ class TestToolWrapper(unittest.TestCase):
                                          fixed_axes=None)
         print(outputs)
 
+        self.assertIsInstance(outputs['bader_result_csv'], get_path_type())
         for act, ref in zip(outputs['net_bader_charges'], ref_results['net_bader_charges']):
             self.assertAlmostEqual(act, ref, delta=1e-3)
         for act, ref in zip(outputs['atom_labels'], ref_results['atom_labels']):
-            self.assertEqual(act, ref)
+            self.assertEqual(act, ref)    
     
     def test_run_abacus_calculation_band(self):
         """


### PR DESCRIPTION
Tools for calculating Bader charges are updated:
- The return key `net_charges` are changed to `net_bader_charges` to be more self-explained and be consistent with tool wrapper.
- Path to a csv file named `bader_charge_results.csv` containing `net_bader_charges` and `atom_labels` will be returned, following developer of MatMaster's request.
- Docstring of exposed mcp tools are updated to be consistent with current behavior.