### PR TITLE
Symmetrize force constants to avoid small negative frequency at gamma-point

### DIFF
--- a/src/abacusagent/modules/submodules/phonon.py
+++ b/src/abacusagent/modules/submodules/phonon.py
@@ -124,6 +124,7 @@ def abacus_phonon_dispersion(
 
         phonon.forces = force_sets
         phonon.produce_force_constants()
+        phonon.symmetrize_force_constants()
 
         phonon.run_mesh([20, 20, 20], with_eigenvectors=True, is_mesh_symmetry=False)
         phonon.run_thermal_properties(temperatures=[temperature])


### PR DESCRIPTION
Symmetrizing the calculated force constants enforces translational and permutation symmetries, which helps eliminate unphysical imaginary frequencies at the Γ point.

This is illustrated by phonon dispersion calculations for NaCl and Fe₂O₃: in both cases, spurious imaginary modes appear near the Γ point when using unsymmetrized force constants, but they vanish entirely after symmetrization.

NaCl, not symmetrized:
<img width="1920" height="1440" alt="phonon_dispersion_dos" src="https://github.com/user-attachments/assets/6baa1f64-dfc6-4c21-afd9-c70c1d614be9" />
NaCl, symmetrized:
<img width="1920" height="1440" alt="phonon_dispersion_dos" src="https://github.com/user-attachments/assets/98e8d6ec-285f-4e57-9112-9123f743dc6d" />

Fe2O3, not symmetrized:
<img width="1920" height="1440" alt="phonon_dispersion_dos" src="https://github.com/user-attachments/assets/7b4bf8c9-214d-4bc5-94f2-662a2243f86e" />
Fe2O3, symmetrized:
<img width="1920" height="1440" alt="image" src="https://github.com/user-attachments/assets/13b8f7f7-f651-47d2-b808-5d965b3b8f53" />
